### PR TITLE
Custom user agent

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -343,7 +343,7 @@ H5_rest_init(hid_t vipl_id)
 {
     herr_t ret_value = SUCCEED;
     curl_version_info_data *curl_ver = NULL;
-    char user_agent[128];
+    char user_agent[128] = {'\0'};
 
     /* Check if already initialized */
     if (H5_rest_initialized_g)
@@ -381,18 +381,14 @@ H5_rest_init(hid_t vipl_id)
 
     /* Set user agent string */
     curl_ver = curl_version_info(CURLVERSION_NOW);
-    if (snprintf(user_agent, sizeof(user_agent),
-                 "libhdf5/%d.%d.%d (%s) VOL-%s/%s libcurl/%s libyajl/%d.%d.%d",
-                 H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE,
-                 curl_ver->host,
-                 HDF5_VOL_REST_NAME, HDF5_VOL_REST_LIB_VER,
-                 curl_ver->version,
-                 YAJL_MAJOR, YAJL_MINOR, YAJL_MICRO) < 0)
+    if (snprintf(user_agent, sizeof(user_agent), "libhdf5/%d.%d.%d (%s; %s v%s)",
+                 H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE, curl_ver->host,
+                 HDF5_VOL_REST_LIB_NAME, HDF5_VOL_REST_LIB_VER) < 0)
     {
         FUNC_GOTO_ERROR(H5E_VOL, H5E_SYSERRSTR, FAIL, "error creating user agent string");
     }
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "error while setting CURL option (CURLOPT_USERAGENT)");
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "error while setting CURL option (CURLOPT_USERAGENT)");
 
 #ifdef RV_CURL_DEBUG
     /* Enable cURL debugging output if desired */

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -27,7 +27,6 @@
 
 #include <curl/curl.h>
 #include <yajl/yajl_tree.h>
-#include <yajl/yajl_version.h>
 
 /* Includes for HDF5 */
 #include "hdf5.h"

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -27,6 +27,7 @@
 
 #include <curl/curl.h>
 #include <yajl/yajl_tree.h>
+#include <yajl/yajl_version.h>
 
 /* Includes for HDF5 */
 #include "hdf5.h"


### PR DESCRIPTION
Since this VOL is a web client I thought it should have a custom user agent to claim its rightful place in the World Wide Web: Below is the current format:
```
User-Agent: libhdf5/1.12.0 (x86_64-apple-darwin17.7.0) VOL-REST/1.0.0 libcurl/7.71.1 libyajl/2.1.0
```
I'm not sure the VOL identifier is the best possible yet, and whether to keep libyajl, but it's a start.