### PR TITLE
Fix empty request on 0-sized write

### DIFF
--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -893,7 +893,8 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t mem_spac
     printf("   \\**********************************/\n\n");
 #endif
 
-    CURL_PERFORM(curl, H5E_DATASET, H5E_WRITEERROR, FAIL);
+    if (write_len > 0)
+        CURL_PERFORM(curl, H5E_DATASET, H5E_WRITEERROR, FAIL);
 
 done:
 #ifdef RV_CONNECTOR_DEBUG


### PR DESCRIPTION
REST VOL used to send a PUT request with an empty body when a 0-element write occurred, which would result in a 400 error from the server.

Now it skips the request if the body is size 0.

A more involved workaround may be needed if parallelism is implemented, since coordination might rely on each worker completing an I/O request.

This fixes the REST VOL's failure on the "creation of 0-sized dataset" from vol-tests.