### PR TITLE
Fix read callback to handle >64kb transfers

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -445,6 +445,7 @@ typedef struct attr_table_entry {
 typedef struct {
     const void *buffer;
     size_t      buffer_size;
+    size_t      bytes_sent;
 } upload_info;
 
 /*

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -281,6 +281,7 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
 
     uinfo.buffer = create_request_body;
     uinfo.buffer_size = (size_t) create_request_body_len;
+    uinfo.bytes_sent = 0;
 
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
@@ -973,6 +974,7 @@ RV_attr_write(void *attr, hid_t dtype_id, const void *buf, hid_t dxpl_id, void *
 
     uinfo.buffer = buf;
     uinfo.buffer_size = write_body_len;
+    uinfo.bytes_sent = 0;
 
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -865,6 +865,7 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t mem_spac
 
     uinfo.buffer = is_transfer_binary ? buf[0] : write_body;
     uinfo.buffer_size = write_body_len;
+    uinfo.bytes_sent = 0;
 
     /* Check to make sure that the size of the write body can safely be cast to a curl_off_t */
     if (sizeof(curl_off_t) < sizeof(size_t))

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -323,6 +323,7 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
 
     uinfo.buffer = create_request_body;
     uinfo.buffer_size = (size_t) create_request_body_len;
+    uinfo.bytes_sent = 0;
 
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);

--- a/test/test_rest_vol.c
+++ b/test/test_rest_vol.c
@@ -8215,7 +8215,6 @@ test_read_dataset_large_point_selection(void)
 {
     hsize_t *points = NULL;
     hsize_t  dims[DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK] = { 600, 600, 600 };
-    size_t   i, data_size;
     hid_t    file_id = -1, fapl_id = -1;
     hid_t    container_group = -1;
     hid_t    dset_id = -1;
@@ -8254,23 +8253,24 @@ test_read_dataset_large_point_selection(void)
         goto error;
     }
 
-    for (i = 0, data_size = 1; i < DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK; i++)
-        data_size *= dims[i];
-    data_size = DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_DTYPESIZE;
+    size_t num_elems = 1;
 
-    if (NULL == (data = malloc(data_size)))
+    for (size_t i = 0; i < DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK; i++)
+        num_elems *= dims[i];
+
+    if (NULL == (data = calloc(num_elems, DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_DTYPESIZE)))
         TEST_ERROR
-    if (NULL == (points = malloc(data_size / DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_DTYPESIZE)))
+    if (NULL == (points = calloc(3 * num_elems, sizeof(hsize_t))))
         TEST_ERROR
 
     /* Select the entire dataspace */
-    for (i = 0; i < data_size / DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_DTYPESIZE; i++) {
+    for (size_t i = 0; i < num_elems; i += 3) {
         points[(i * DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK)] = (i % (dims[0] * dims[1])) % dims[1];
         points[(i * DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK) + 1] = (i % (dims[0] * dims[1])) / dims[0];
         points[(i * DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_SPACE_RANK) + 2] = (i / (dims[0] * dims[1]));
     }
 
-    if (H5Sselect_elements(fspace_id, H5S_SELECT_SET, data_size / DATASET_LARGE_READ_TEST_POINT_SELECTION_DSET_DTYPESIZE, points) < 0) {
+    if (H5Sselect_elements(fspace_id, H5S_SELECT_SET, num_elems, points) < 0) {
         H5_FAILED();
         printf("    couldn't select points\n");
         goto error;


### PR DESCRIPTION
curl uses an internal buffer of size 64kb. When the VOL had a payload larger than that to upload, the read data callback would copy the first 64kb of data each time, and never return 0 to indicate the transfer was finished. It would continue to write to the server until the server closed its end of the connection.

Also fixed the read large point selection test to no longer access invalid memory. If run, it now receives a
413 Entity too large error from HSDS instead.