### PR TITLE
Fix external links for groups, dsets, dtypes

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -1661,22 +1661,16 @@ done:
 herr_t RV_copy_object_URI_and_domain_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out) {
     herr_t ret_value = SUCCEED;
     RV_object_t *parent_object = (RV_object_t*) callback_data_in;
-    void  *URI_domain_ptrs[2];
-    void  *URI_buffer = NULL;
-
-    memcpy(URI_domain_ptrs, callback_data_out, sizeof(void*) * 2);
-    
-    URI_buffer = URI_domain_ptrs[0];
+    loc_info    *loc_info_out = (loc_info*) callback_data_out;
 
     if (parent_object) {
         /* Close reference to previous domain */
-        void **domain_buffer_ptr = (((char*) callback_data_out) + sizeof(void*));
-        RV_file_close(*domain_buffer_ptr, H5P_DEFAULT, NULL);
+        RV_file_close(loc_info_out->domain, H5P_DEFAULT, NULL);
         
-        if (RV_file_create_new_reference(parent_object, domain_buffer_ptr) < 0)
+        if (RV_file_create_new_reference(parent_object, &loc_info_out->domain) < 0)
             FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy object domain");
 
-        ret_value = RV_copy_object_URI_callback(HTTP_response, NULL, URI_buffer);
+        ret_value = RV_copy_object_URI_callback(HTTP_response, NULL, loc_info_out->URI);
     } else {
         ret_value = FAIL;
     }

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -1667,8 +1667,8 @@ herr_t RV_copy_object_URI_and_domain_callback(char *HTTP_response, void *callbac
         /* Close reference to previous domain */
         RV_file_close(loc_info_out->domain, H5P_DEFAULT, NULL);
         
-        if (RV_file_create_new_reference(parent_object, &loc_info_out->domain) < 0)
-            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy object domain");
+        loc_info_out->domain = parent_object;
+        parent_object->u.file.ref_count++;
 
         ret_value = RV_copy_object_URI_callback(HTTP_response, NULL, loc_info_out->URI);
     } else {

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -458,6 +458,7 @@ typedef struct RV_object_t RV_object_t;
 
 typedef struct RV_file_t {
     unsigned  intent;
+    unsigned  ref_count;
     char     *filepath_name;
     hid_t     fcpl_id;
     hid_t     fapl_id;

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -506,6 +506,13 @@ struct RV_object_t {
     } u;
 };
 
+/* A strcture which is filled out by a callback that reads
+ * the server's response, containing information that uniquely
+ * identifies an object by URI and the domain containing it. */
+typedef struct loc_info {
+    char *URI;
+    RV_object_t *domain;
+} loc_info;
 
 /****************************
  *                          *

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -531,6 +531,9 @@ herr_t RV_parse_response(char *HTTP_response, void *callback_data_in, void *call
 /* Callback for RV_parse_response() to capture an object's URI */
 herr_t RV_copy_object_URI_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
 
+/* Callback for RV_parse_response() to capture an object's URI and domain, for external links */
+herr_t RV_copy_object_URI_and_domain_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
+
 /* Helper function to find an object given a starting object to search from and a path */
 htri_t RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t *target_object_type,
        herr_t (*obj_found_callback)(char *, void *, void *), void *callback_data_in, void *callback_data_out);

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -1780,17 +1780,6 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
                         parent_obj_type == H5I_DATATYPE) {
                             
                         loc_obj->domain->u.file.ref_count++;
-
-                        if (loc_obj->domain->u.file.fapl_id >= 0) {
-                            if ((loc_obj->domain->u.file.fapl_id != H5P_FILE_ACCESS_DEFAULT) && (H5Iinc_ref(loc_obj->domain->u.file.fapl_id) < 0))
-                                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't increase ref count of FAPL");
-                        } /* end if */
-
-                        if (loc_obj->domain->u.file.fcpl_id >= 0) {
-                            if ((loc_obj->domain->u.file.fcpl_id != H5P_FILE_CREATE_DEFAULT) && (H5Iinc_ref(loc_obj->domain->u.file.fcpl_id) < 0))
-                                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't increase ref count of FCPL");
-                        } /* end if */
-
                     }
 
                     /* Increment refs for specific type */

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -111,8 +111,8 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
     new_attribute->u.attribute.acpl_id = FAIL;
     new_attribute->u.attribute.attr_name = NULL;
     
-    if (RV_file_create_new_reference(parent->domain, &new_attribute->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy attr domain");
+    new_attribute->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
 
     /* If this is a call to H5Acreate_by_name, locate the real parent object */
     if (H5VL_OBJECT_BY_NAME == loc_params->type) {
@@ -426,9 +426,8 @@ RV_attr_open(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_na
     attribute->u.attribute.acpl_id = FAIL;
     attribute->u.attribute.attr_name = NULL;
 
-    if (RV_file_create_new_reference(parent->domain, &attribute->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy attr domain");
-
+    attribute->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
 
     /* Set the parent object's type and URI in the attribute's appropriate fields */
     switch (loc_params->type) {

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -135,18 +135,9 @@ RV_dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const char *na
     new_dataset->u.dataset.dapl_id = FAIL;
     new_dataset->u.dataset.dcpl_id = FAIL;
     
-    if (RV_file_create_new_reference(parent->domain, &new_dataset->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy dataset domain");
-
-    /* Copy information about file that the newly-created dataset is in */
-    /*
-    new_dataset->domain = RV_malloc(sizeof(*parent->domain));
-    memcpy(new_dataset->domain, parent->domain, sizeof(*parent->domain));
-
-    new_dataset->domain->u.file.filepath_name = RV_malloc(strlen(parent->domain->u.file.filepath_name) + 1);
-    strncpy(new_dataset->domain->u.file.filepath_name, parent->domain->u.file.filepath_name, strlen(parent->domain->u.file.filepath_name) + 1);
-    */
-
+    new_dataset->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
+    
     /* Copy the DAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Dget_access_plist() will function correctly
      */
@@ -327,9 +318,9 @@ RV_dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     dataset->u.dataset.dcpl_id = FAIL;
 
     /* Copy information about file that the newly-created dataset is in */
-    if (RV_file_create_new_reference(parent->domain, &dataset->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy dataset domain");
-
+    dataset->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
+    
     loc_info.URI = dataset->URI;
     loc_info.domain = dataset->domain;
 

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -299,6 +299,7 @@ RV_dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     RV_object_t *parent = (RV_object_t *) obj;
     RV_object_t *dataset = NULL;
     H5I_type_t   obj_type = H5I_UNINIT;
+    loc_info     loc_info;
     htri_t       search_ret;
     void        *ret_value = NULL;
 
@@ -329,20 +330,15 @@ RV_dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     if (RV_file_create_new_reference(parent->domain, &dataset->domain) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy dataset domain");
 
-    
-
-    /* Buffer to hold URI and domain ptrs */
-    void *URI_domain_ptrs[2];
-
-    URI_domain_ptrs[0] = dataset->URI;
-    URI_domain_ptrs[1] = dataset->domain;
+    loc_info.URI = dataset->URI;
+    loc_info.domain = dataset->domain;
 
     /* Locate dataset and set domain */
-    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &URI_domain_ptrs);
+    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &loc_info);
     if (!search_ret || search_ret < 0)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_PATH, NULL, "can't locate dataset by path");
 
-    dataset->domain = URI_domain_ptrs[1];
+    dataset->domain = loc_info.domain;
     
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Found dataset by given path\n\n");

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -329,6 +329,7 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
     RV_object_t *parent = (RV_object_t *) obj;
     RV_object_t *datatype = NULL;
     H5I_type_t   obj_type = H5I_UNINIT;
+    loc_info     loc_info;
     htri_t       search_ret;
     void        *ret_value = NULL;
 
@@ -358,18 +359,15 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
     if (RV_file_create_new_reference(parent->domain, &datatype->domain) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy datatype domain");
 
-    /* Buffer to hold URI and domain ptrs */
-    void *URI_domain_ptrs[2];
-
-    URI_domain_ptrs[0] = datatype->URI;
-    URI_domain_ptrs[1] = datatype->domain;
+    loc_info.URI = datatype->URI;
+    loc_info.domain = datatype->domain;
 
     /* Locate datatype and set domain */
-    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &URI_domain_ptrs);
+    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &loc_info);
     if (!search_ret || search_ret < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_PATH, NULL, "can't locate datatype by path");
 
-    datatype->domain = URI_domain_ptrs[1];
+    datatype->domain = loc_info.domain;
     
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Found datatype by given path\n\n");

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -115,12 +115,9 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     new_datatype->u.datatype.tapl_id = FAIL;
     new_datatype->u.datatype.tcpl_id = FAIL;
     
-    /* Copy information about file that the newly-created datatype is in */
-    if (RV_file_create_new_reference(parent->domain, &new_datatype->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy datatype domain");
-
+    new_datatype->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
     
-
     /* Copy the TAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * datatype access property list functions will function correctly
      */
@@ -355,10 +352,9 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
     datatype->u.datatype.tapl_id = FAIL;
     datatype->u.datatype.tcpl_id = FAIL;
     
-    /* Copy information about file that the datatype is in */
-    if (RV_file_create_new_reference(parent->domain, &datatype->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy datatype domain");
-
+    datatype->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
+    
     loc_info.URI = datatype->URI;
     loc_info.domain = datatype->domain;
 

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -658,16 +658,16 @@ RV_file_close(void *file, hid_t dxpl_id, void **req)
 
     _file->u.file.ref_count--;
 
-    if (_file->u.file.fapl_id >= 0) {
-        if (_file->u.file.fapl_id != H5P_FILE_ACCESS_DEFAULT && H5Pclose(_file->u.file.fapl_id) < 0)
-            FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't close FAPL");
-    } /* end if */
-    if (_file->u.file.fcpl_id >= 0) {
-        if (_file->u.file.fcpl_id != H5P_FILE_CREATE_DEFAULT && H5Pclose(_file->u.file.fcpl_id) < 0)
-            FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't close FCPL");
-    } /* end if */
-
     if (_file->u.file.ref_count == 0) {
+        if (_file->u.file.fapl_id >= 0) {
+            if (_file->u.file.fapl_id != H5P_FILE_ACCESS_DEFAULT && H5Pclose(_file->u.file.fapl_id) < 0)
+                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't close FAPL");
+        } /* end if */
+        if (_file->u.file.fcpl_id >= 0) {
+            if (_file->u.file.fcpl_id != H5P_FILE_CREATE_DEFAULT && H5Pclose(_file->u.file.fcpl_id) < 0)
+                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't close FCPL");
+        } /* end if */
+
         if (_file->u.file.filepath_name) {
             RV_free(_file->u.file.filepath_name);
             _file->u.file.filepath_name = NULL;
@@ -683,52 +683,3 @@ done:
 
     return ret_value;
 } /* end RV_file_close() */
-
-
-/*-------------------------------------------------------------------------
- * Function:    RV_file_create_new_reference
- *
- * Purpose:     This function handles increasing the reference count of 
- *              a top-level file's object struct. 
- * 
- *              original_domain should be the address of a top-level file
- *              which is being referred to by a newly opened or created child object,
- *              
- *              new_domain_ptr should be the address of a pointer
- *              that will be used by that child object to point at the file.
- *
- * Return:      Non-negative on success/Negative on failure
- *
- * Programmer:  Matthew Larson
- *              April, 2023
- */
-herr_t
-RV_file_create_new_reference(void *original_domain, void** new_domain_ptr) {
-    herr_t ret_value = SUCCEED;
-    *new_domain_ptr = original_domain;
-    RV_object_t *_original_domain = (RV_object_t*) original_domain;
-
-    if (_original_domain) {
-        _original_domain->u.file.ref_count++;
-
-        if (_original_domain->u.file.fapl_id >= 0) {
-            if ((_original_domain->u.file.fapl_id != H5P_FILE_ACCESS_DEFAULT) && (H5Iinc_ref(_original_domain->u.file.fapl_id) < 0))
-                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't increase ref count of FAPL");
-        } /* end if */
-
-        if (_original_domain->u.file.fcpl_id >= 0) {
-            if ((_original_domain->u.file.fcpl_id != H5P_FILE_CREATE_DEFAULT) && (H5Iinc_ref(_original_domain->u.file.fcpl_id) < 0))
-                FUNC_DONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "can't increase ref count of FCPL");
-        } /* end if */
-
-    } else {
-        FUNC_DONE_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "unable to create new reference to file");
-    }
-
-
-done:
-    return ret_value;
-}
-
-
-

--- a/src/rest_vol_file.h
+++ b/src/rest_vol_file.h
@@ -23,6 +23,7 @@ void   *RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl
 herr_t  RV_file_get(void *obj, H5VL_file_get_args_t *args, hid_t dxpl_id, void **req);
 herr_t  RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void **req);
 herr_t  RV_file_close(void *file, hid_t dxpl_id, void **req);
+herr_t  RV_file_create_new_reference(void *file, void **new_file);
 
 #ifdef __cplusplus
 }

--- a/src/rest_vol_file.h
+++ b/src/rest_vol_file.h
@@ -23,7 +23,6 @@ void   *RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl
 herr_t  RV_file_get(void *obj, H5VL_file_get_args_t *args, hid_t dxpl_id, void **req);
 herr_t  RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void **req);
 herr_t  RV_file_close(void *file, hid_t dxpl_id, void **req);
-herr_t  RV_file_create_new_reference(void *file, void **new_file);
 
 #ifdef __cplusplus
 }

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -81,10 +81,9 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     new_group->u.group.gapl_id = FAIL;
     new_group->u.group.gcpl_id = FAIL;
 
-    /* Copy information about file the newly-created group is in */
-    if (RV_file_create_new_reference(parent->domain, &new_group->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy group domain");
-
+    new_group->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
+    
     /* Copy the GAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * group access property list functions will function correctly
      */
@@ -323,9 +322,9 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name,
     group->u.group.gcpl_id = FAIL;
 
     /* Copy information about file the group is in */
-    if (RV_file_create_new_reference(parent->domain, &group->domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy group domain");
-
+    group->domain = parent->domain;
+    parent->domain->u.file.ref_count++;
+    
     loc_info.URI = group->URI;
     loc_info.domain = group->domain;
 

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -297,6 +297,7 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name,
     RV_object_t *parent = (RV_object_t *) obj;
     RV_object_t *group = NULL;
     H5I_type_t   obj_type = H5I_UNINIT;
+    loc_info     loc_info;
     htri_t       search_ret;
     void        *ret_value = NULL;
 
@@ -325,18 +326,15 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name,
     if (RV_file_create_new_reference(parent->domain, &group->domain) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy group domain");
 
-    /* Buffer to hold URI and domain ptrs */
-    void *URI_domain_ptrs[2];
-
-    URI_domain_ptrs[0] = group->URI;
-    URI_domain_ptrs[1] = group->domain;
+    loc_info.URI = group->URI;
+    loc_info.domain = group->domain;
 
     /* Locate group and set domain */
-    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &URI_domain_ptrs);
+    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &loc_info);
     if (!search_ret || search_ret < 0)
         FUNC_GOTO_ERROR(H5E_SYM, H5E_PATH, NULL, "can't locate group by path");
 
-    group->domain = URI_domain_ptrs[1];
+    group->domain = loc_info.domain;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Found group by given path\n\n");

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -245,9 +245,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     char         request_url[URL_MAX_LENGTH];
     int          url_len = 0;
     herr_t       ret_value = SUCCEED;
-    RV_object_t *domain = NULL;
+    loc_info     loc_info;
     
-    if (RV_file_create_new_reference(loc_obj->domain, &domain) < 0)
+    if (RV_file_create_new_reference(loc_obj->domain, &loc_info.domain) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy object domain");
 
 #ifdef RV_CONNECTOR_DEBUG
@@ -358,18 +358,14 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                     printf("-> H5Oget_info_by_name(): locating object by given path\n\n");
 #endif
 
-                    void *URI_domain_ptrs[2];
-
-                    URI_domain_ptrs[0] = temp_URI;
-                    URI_domain_ptrs[1] = domain;
+                    loc_info.URI = temp_URI;
+                    /* loc_info.domain was copied at function start */
 
                     /* Locate group and set domain */
                     search_ret = RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name, \
-                        &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &URI_domain_ptrs);
+                        &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &loc_info);
                     if (!search_ret || search_ret < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, NULL, "can't locate object by path");
-
-                    domain = URI_domain_ptrs[1];
 
 #ifdef RV_CONNECTOR_DEBUG
                     printf("-> H5Oget_info_by_name(): found object by given path\n");
@@ -451,13 +447,13 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
 
             /* Setup the host header */
-            host_header_len = strlen(domain->u.file.filepath_name) + strlen(host_string) + 1;
+            host_header_len = strlen(loc_info.domain->u.file.filepath_name) + strlen(host_string) + 1;
             if (NULL == (host_header = (char *) RV_malloc(host_header_len)))
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
 
             strcpy(host_header, host_string);
 
-            curl_headers = curl_slist_append(curl_headers, strncat(host_header, domain->u.file.filepath_name, host_header_len - strlen(host_string) - 1));
+            curl_headers = curl_slist_append(curl_headers, strncat(host_header, loc_info.domain->u.file.filepath_name, host_header_len - strlen(host_string) - 1));
 
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
@@ -509,7 +505,7 @@ done:
         curl_headers = NULL;
     } /* end if */
 
-    RV_file_close(domain, H5P_DEFAULT, NULL);
+    RV_file_close(loc_info.domain, H5P_DEFAULT, NULL);
     
     PRINT_ERROR_STACK;
 

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -247,9 +247,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     herr_t       ret_value = SUCCEED;
     loc_info     loc_info;
     
-    if (RV_file_create_new_reference(loc_obj->domain, &loc_info.domain) < 0)
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCOPY, FAIL, "couldn't copy object domain");
-
+    loc_info.domain = loc_obj->domain;
+    loc_obj->domain->u.file.ref_count++;
+    
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received object get call with following parameters:\n");
     printf("     - Object get call type: %s\n", object_get_type_to_string(args->op_type));

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -245,6 +245,13 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     char         request_url[URL_MAX_LENGTH];
     int          url_len = 0;
     herr_t       ret_value = SUCCEED;
+    RV_object_t *domain = RV_malloc(sizeof(RV_object_t));
+
+    memcpy(domain, loc_obj->domain, sizeof(RV_object_t));
+    domain->u.file.filepath_name = RV_malloc(strlen(loc_obj->domain->u.file.filepath_name) + 1);
+    
+    
+    strncpy(domain->u.file.filepath_name, loc_obj->domain->u.file.filepath_name, strlen(loc_obj->domain->u.file.filepath_name) + 1);
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received object get call with following parameters:\n");
@@ -354,10 +361,16 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                     printf("-> H5Oget_info_by_name(): locating object by given path\n\n");
 #endif
 
-                    search_ret = RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name, &obj_type,
-                            RV_copy_object_URI_callback, NULL, temp_URI);
+                    void *URI_domain_ptrs[2];
+
+                    URI_domain_ptrs[0] = temp_URI;
+                    URI_domain_ptrs[1] = domain;
+
+                    /* Locate group and set domain */
+                    search_ret = RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name, \
+                        &obj_type, RV_copy_object_URI_and_domain_callback, NULL, &URI_domain_ptrs);
                     if (!search_ret || search_ret < 0)
-                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "can't locate object");
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, NULL, "can't locate object by path");
 
 #ifdef RV_CONNECTOR_DEBUG
                     printf("-> H5Oget_info_by_name(): found object by given path\n");
@@ -439,13 +452,13 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
 
             /* Setup the host header */
-            host_header_len = strlen(loc_obj->domain->u.file.filepath_name) + strlen(host_string) + 1;
+            host_header_len = strlen(domain->u.file.filepath_name) + strlen(host_string) + 1;
             if (NULL == (host_header = (char *) RV_malloc(host_header_len)))
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
 
             strcpy(host_header, host_string);
 
-            curl_headers = curl_slist_append(curl_headers, strncat(host_header, loc_obj->domain->u.file.filepath_name, host_header_len - strlen(host_string) - 1));
+            curl_headers = curl_slist_append(curl_headers, strncat(host_header, domain->u.file.filepath_name, host_header_len - strlen(host_string) - 1));
 
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
@@ -496,6 +509,11 @@ done:
         curl_slist_free_all(curl_headers);
         curl_headers = NULL;
     } /* end if */
+
+    if (domain)
+        RV_free(domain->u.file.filepath_name);
+    
+    RV_free(domain);
 
     PRINT_ERROR_STACK;
 


### PR DESCRIPTION
Groups, datasets, and datatypes from an external file now correctly indicate this in their domain field upon being opened. 

H5Oget_info_by_name now correctly retrieves external links' domain.

Fix for #24 , #30

