### PR TITLE
Keep track of HSDS version

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -3080,15 +3080,16 @@ done:
 } /* end RV_base64_decode() */
 /* Helper function to store the version of the external HSDS server */
 herr_t
-RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callback_data_out) {
-    yajl_val    parse_tree       = NULL, key_obj;
-    herr_t      ret_value        = SUCCEED;
-    server_api_version *server_version = (server_api_version *) callback_data_out;
+RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+{
+    yajl_val            parse_tree     = NULL, key_obj;
+    herr_t              ret_value      = SUCCEED;
+    server_api_version *server_version = (server_api_version *)callback_data_out;
 
-    char       *version_response = NULL;
-    char       *version_field    = NULL;
-    char       *saveptr;
-    int         numeric_version_field    = 0;
+    char *version_response = NULL;
+    char *version_field    = NULL;
+    char *saveptr;
+    int   numeric_version_field = 0;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Retrieving server version from server's HTTP response\n\n");
@@ -3120,7 +3121,7 @@ RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callb
     if ((numeric_version_field = strtol(version_field, NULL, 10)) < 0)
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "invalid server major version");
 
-    server_version->major = (size_t) numeric_version_field;
+    server_version->major = (size_t)numeric_version_field;
 
     if (NULL == (version_field = strtok_r(NULL, ".", &saveptr)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "server minor version field was NULL");
@@ -3128,7 +3129,7 @@ RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callb
     if ((numeric_version_field = strtol(version_field, NULL, 10)) < 0)
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "invalid server minor version");
 
-    server_version->minor = (size_t) numeric_version_field;
+    server_version->minor = (size_t)numeric_version_field;
 
     if (NULL == (version_field = strtok_r(NULL, ".", &saveptr)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "server patch version field was NULL");
@@ -3136,7 +3137,7 @@ RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callb
     if ((numeric_version_field = strtol(version_field, NULL, 10)) < 0)
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "invalid server patch version");
 
-    server_version->patch = (size_t) numeric_version_field;
+    server_version->patch = (size_t)numeric_version_field;
 
 done:
     if (parse_tree)

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -467,11 +467,11 @@ typedef struct server_api_version {
 typedef struct RV_object_t RV_object_t;
 
 typedef struct RV_file_t {
-    unsigned intent;
-    unsigned ref_count;
-    char    *filepath_name;
-    hid_t    fcpl_id;
-    hid_t    fapl_id;
+    unsigned           intent;
+    unsigned           ref_count;
+    char              *filepath_name;
+    hid_t              fcpl_id;
+    hid_t              fapl_id;
     server_api_version server_version;
 } RV_file_t;
 

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -361,6 +361,9 @@ extern const char *object_id_keys[];
 extern const char *link_class_keys[];
 extern const char *link_class_keys2[];
 
+/* JSON key to retrieve the version of server from a request to a file. */
+extern const char *server_version_keys[];
+
 /* A global struct containing the buffer which cURL will write its
  * responses out to after making a call to the server. The buffer
  * in this struct is allocated upon connector initialization and is
@@ -448,6 +451,13 @@ typedef struct {
     size_t      bytes_sent;
 } upload_info;
 
+/* Structure that keeps track of semantic version. */
+typedef struct server_api_version {
+    size_t major;
+    size_t minor;
+    size_t patch;
+} server_api_version;
+
 /*
  * Definitions for the basic objects which the REST VOL uses
  * to represent various HDF5 objects internally. The base object
@@ -462,6 +472,7 @@ typedef struct RV_file_t {
     char    *filepath_name;
     hid_t    fcpl_id;
     hid_t    fapl_id;
+    server_api_version server_version;
 } RV_file_t;
 
 typedef struct RV_group_t {
@@ -544,6 +555,9 @@ herr_t RV_copy_object_URI_callback(char *HTTP_response, void *callback_data_in, 
 
 /* Callback for RV_parse_response() to capture an object's creation properties */
 herr_t RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
+
+/* Callback for RV_parse_response() to capture the version of the server api */
+herr_t RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callback_data_out);
 
 /* Helper function to find an object given a starting object to search from and a path */
 htri_t RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t *target_object_type,

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -244,6 +244,10 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     if (RV_parse_response(response_buffer.buffer, NULL, new_file->URI, RV_copy_object_URI_callback) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse new file's URI");
 
+    /* Store server version */
+    if (RV_parse_response(response_buffer.buffer, NULL, &new_file->u.file.server_version, RV_parse_server_version) < 0)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse server  version");
+
     ret_value = (void *)new_file;
 
 done:
@@ -385,6 +389,10 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     /* Store the opened file's URI */
     if (RV_parse_response(response_buffer.buffer, NULL, file->URI, RV_copy_object_URI_callback) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't parse file's URI");
+
+    /* Store server version */
+    if (RV_parse_response(response_buffer.buffer, NULL, &file->u.file.server_version, RV_parse_server_version) < 0)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse server version");
 
     /* Copy the FAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Fget_access_plist() will function correctly

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -245,7 +245,8 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse new file's URI");
 
     /* Store server version */
-    if (RV_parse_response(response_buffer.buffer, NULL, &new_file->u.file.server_version, RV_parse_server_version) < 0)
+    if (RV_parse_response(response_buffer.buffer, NULL, &new_file->u.file.server_version,
+                          RV_parse_server_version) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse server  version");
 
     ret_value = (void *)new_file;
@@ -391,7 +392,8 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't parse file's URI");
 
     /* Store server version */
-    if (RV_parse_response(response_buffer.buffer, NULL, &file->u.file.server_version, RV_parse_server_version) < 0)
+    if (RV_parse_response(response_buffer.buffer, NULL, &file->u.file.server_version,
+                          RV_parse_server_version) < 0)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't parse server version");
 
     /* Copy the FAPL if it wasn't H5P_DEFAULT, else set up a default one so that


### PR DESCRIPTION
This will be useful for reverting to old `RV_find_object_by_path` behavior for old versions of HSDS that don't include the changes from HDFGroup/HSDS#224