### PR TITLE
Support H5Iget name

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -2462,7 +2462,12 @@ RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, vo
         new_domain->u.file.fcpl_id        = H5Pcopy(loc_info_out->domain->u.file.fcpl_id);
         new_domain->u.file.ref_count      = 1;
         new_domain->u.file.server_version = found_domain.u.file.server_version;
-        new_domain->handle_path           = "/";
+            
+        /* Allocate root "path" on heap for consistency with other RV_object_t types */
+        if ((new_domain->handle_path = RV_malloc(2)) == NULL)
+            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");
+
+        strncpy(new_domain->handle_path, "/", 2);
 
         /* Assume that original domain and external domain have the same server version.
          * This will always be true unless it becomes possible for external links to point to

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -3387,14 +3387,16 @@ done:
     return (ret_value);
 } /* end RV_set_object_type_header */
 
-/* Helper function to initialize an object's name based on its parent's name. 
+/* Helper function to initialize an object's name based on its parent's name.
  * Allocates memory that must be closed by caller. */
-herr_t RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **buf) {
-    herr_t ret_value = SUCCEED;
+herr_t
+RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **buf)
+{
+    herr_t  ret_value           = SUCCEED;
     hbool_t include_parent_path = false;
-    size_t path_size = 0;
-    size_t path_len = 0;
-    char *handle_path = NULL;
+    size_t  path_size           = 0;
+    size_t  path_len            = 0;
+    char   *handle_path         = NULL;
 
     /* Objects can be created/opened without reference to their path. Leave handle_path NULL in this case */
     if (!obj_path) {
@@ -3405,9 +3407,8 @@ herr_t RV_set_object_handle_path(const char *obj_path, const char *parent_path, 
     /* Parent name is included if it is not the root and the object is opened by relative path */
     include_parent_path = parent_path && strcmp(parent_path, "/") && (obj_path[0] != '/');
 
-    path_size = include_parent_path ? 
-        strlen(parent_path) + 1 + strlen(obj_path) + 1 
-        : 1 + strlen(obj_path) + 1;
+    path_size =
+        include_parent_path ? strlen(parent_path) + 1 + strlen(obj_path) + 1 : 1 + strlen(obj_path) + 1;
 
     if ((handle_path = RV_malloc(path_size)) == NULL)
         FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -2462,7 +2462,7 @@ RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, vo
         new_domain->u.file.fcpl_id        = H5Pcopy(loc_info_out->domain->u.file.fcpl_id);
         new_domain->u.file.ref_count      = 1;
         new_domain->u.file.server_version = found_domain.u.file.server_version;
-            
+
         /* Allocate root "path" on heap for consistency with other RV_object_t types */
         if ((new_domain->handle_path = RV_malloc(2)) == NULL)
             FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -3411,10 +3411,10 @@ RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **
         include_parent_path ? strlen(parent_path) + 1 + strlen(obj_path) + 1 : 1 + strlen(obj_path) + 1;
 
     if ((handle_path = RV_malloc(path_size)) == NULL)
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, FAIL, "can't allocate space for handle path");
 
     if (include_parent_path) {
-        strncpy(handle_path, parent_path, strlen(parent_path));
+        strncpy(handle_path, parent_path, path_size);
         path_len += strlen(parent_path);
     }
 
@@ -3427,6 +3427,8 @@ RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **
     strncpy(handle_path + path_len, obj_path, strlen(obj_path) + 1);
     path_len += (strlen(obj_path) + 1);
 
+    handle_path[path_size - 1] = '\0';
+    
     /* Make user pointer point at allocated memory */
     *buf = handle_path;
 

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -2437,6 +2437,8 @@ RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, vo
         new_domain->u.file.fapl_id   = H5Pcopy(loc_info_out->domain->u.file.fapl_id);
         new_domain->u.file.fcpl_id   = H5Pcopy(loc_info_out->domain->u.file.fcpl_id);
         new_domain->u.file.ref_count = 1;
+        new_domain->u.file.server_version = found_domain.u.file.server_version;
+        new_domain->handle_path = "/";
 
         /* Assume that original domain and external domain have the same server version.
          * This will always be true unless it becomes possible for external links to point to

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -3428,7 +3428,7 @@ RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **
     path_len += (strlen(obj_path) + 1);
 
     handle_path[path_size - 1] = '\0';
-    
+
     /* Make user pointer point at allocated memory */
     *buf = handle_path;
 

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -2433,12 +2433,12 @@ RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, vo
         strncpy(new_domain->u.file.filepath_name, found_domain.u.file.filepath_name,
                 strlen(found_domain.u.file.filepath_name) + 1);
 
-        new_domain->u.file.intent    = loc_info_out->domain->u.file.intent;
-        new_domain->u.file.fapl_id   = H5Pcopy(loc_info_out->domain->u.file.fapl_id);
-        new_domain->u.file.fcpl_id   = H5Pcopy(loc_info_out->domain->u.file.fcpl_id);
-        new_domain->u.file.ref_count = 1;
+        new_domain->u.file.intent         = loc_info_out->domain->u.file.intent;
+        new_domain->u.file.fapl_id        = H5Pcopy(loc_info_out->domain->u.file.fapl_id);
+        new_domain->u.file.fcpl_id        = H5Pcopy(loc_info_out->domain->u.file.fcpl_id);
+        new_domain->u.file.ref_count      = 1;
         new_domain->u.file.server_version = found_domain.u.file.server_version;
-        new_domain->handle_path = "/";
+        new_domain->handle_path           = "/";
 
         /* Assume that original domain and external domain have the same server version.
          * This will always be true unless it becomes possible for external links to point to

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -473,6 +473,7 @@ typedef struct RV_attr_t {
     hid_t      aapl_id;
     hid_t      acpl_id;
     char      *attr_name;
+    char      *parent_name;
 } RV_attr_t;
 
 typedef struct RV_datatype_t {
@@ -485,6 +486,7 @@ struct RV_object_t {
     RV_object_t *domain;
     H5I_type_t   obj_type;
     char         URI[URI_MAX_LENGTH];
+    char        *handle_path;
 
     union {
         RV_datatype_t datatype;

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -625,6 +625,9 @@ herr_t RV_base64_decode(const char *in, size_t in_size, char **out, size_t *out_
 /* Comparison function to compare two keys in an rv_hash_table_t */
 int H5_rest_compare_string_keys(void *value1, void *value2);
 
+/* Helper function to initialize an object's name based on its parent's name. */
+herr_t RV_set_object_handle_path(const char *obj_path, const char *parent_path, char **buf);
+
 /* Helper to turn an object type into a string for a server request */
 herr_t RV_set_object_type_header(H5I_type_t parent_obj_type, const char **parent_obj_type_header);
 

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -118,30 +118,8 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
 
     new_attribute->handle_path = NULL;
 
-    if (attr_name) {
-        /* Parent name is included if it is not the root */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/");
-
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1
-                                         : 1 + strlen(attr_name) + 1);
-
-        if ((new_attribute->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(new_attribute->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in attribute name */
-        if (attr_name[0] != '/') {
-            new_attribute->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(new_attribute->handle_path + path_len, attr_name, strlen(attr_name) + 1);
-        path_len += (strlen(attr_name) + 1);
-    }
+    if (RV_set_object_handle_path(attr_name, parent->handle_path, &new_attribute->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_ATTR, H5E_PATH, NULL, "can't set up object path");
 
     new_attribute->u.attribute.parent_name = NULL;
 
@@ -498,30 +476,8 @@ RV_attr_open(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_na
 
     attribute->handle_path = NULL;
 
-    if (attr_name) {
-        /* Parent name is included if it is not the root */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/");
-
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1
-                                         : 1 + strlen(attr_name) + 1);
-
-        if ((attribute->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(attribute->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in attribute name */
-        if (attr_name[0] != '/') {
-            attribute->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(attribute->handle_path + path_len, attr_name, strlen(attr_name) + 1);
-        path_len += (strlen(attr_name) + 1);
-    }
+    if (RV_set_object_handle_path(attr_name, parent->handle_path, &attribute->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_ATTR, H5E_PATH, NULL, "can't set up object path");
 
     attribute->u.attribute.parent_name = NULL;
 

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -120,12 +120,13 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
 
     if (attr_name) {
         /* Parent name is included if it is not the root */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/"); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/");
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1 : 1 + strlen(attr_name) + 1);
-        
+        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1
+                                         : 1 + strlen(attr_name) + 1);
+
         if ((new_attribute->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(new_attribute->handle_path, parent->handle_path, strlen(parent->handle_path));
@@ -499,12 +500,13 @@ RV_attr_open(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_na
 
     if (attr_name) {
         /* Parent name is included if it is not the root */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/"); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/");
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1 : 1 + strlen(attr_name) + 1);
-        
+        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(attr_name) + 1
+                                         : 1 + strlen(attr_name) + 1);
+
         if ((attribute->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(attribute->handle_path, parent->handle_path, strlen(parent->handle_path));
@@ -2247,10 +2249,12 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
 
                     RV_object_t *attr_iter_obj = (RV_object_t *)attr_iter_object;
 
-                    if ((attr_iter_obj->handle_path = RV_malloc(strlen(loc_obj->handle_path) +1)) == NULL)
-                        FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "can't allocate space for copy of object path");
+                    if ((attr_iter_obj->handle_path = RV_malloc(strlen(loc_obj->handle_path) + 1)) == NULL)
+                        FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL,
+                                        "can't allocate space for copy of object path");
 
-                    strncpy(attr_iter_obj->handle_path, loc_obj->handle_path, strlen(loc_obj->handle_path) + 1);
+                    strncpy(attr_iter_obj->handle_path, loc_obj->handle_path,
+                            strlen(loc_obj->handle_path) + 1);
 
                     switch (parent_obj_type) {
                         case H5I_FILE:

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -150,12 +150,13 @@ RV_dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const char *na
 
     if (name) {
         /* Parent name is included if it is not the root and the dataset is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((new_dataset->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(new_dataset->handle_path, parent->handle_path, strlen(parent->handle_path));
@@ -365,12 +366,13 @@ RV_dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     if (name) {
         /* Parent name is included if it is not the root and the dataset is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((dataset->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(dataset->handle_path, parent->handle_path, strlen(parent->handle_path));

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -148,30 +148,8 @@ RV_dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const char *na
 
     new_dataset->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the dataset is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((new_dataset->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(new_dataset->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in dataset path */
-        if (name[0] != '/') {
-            new_dataset->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(new_dataset->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &new_dataset->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_DATASET, H5E_PATH, NULL, "can't set up object path");
 
     /* Copy the DAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Dget_access_plist() will function correctly
@@ -364,30 +342,8 @@ RV_dataset_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     dataset->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the dataset is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((dataset->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(dataset->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in dataset path */
-        if (name[0] != '/') {
-            dataset->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(dataset->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &dataset->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_DATASET, H5E_PATH, NULL, "can't set up object path");
 
     loc_info_out.URI         = dataset->URI;
     loc_info_out.domain      = dataset->domain;

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -123,12 +123,13 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
 
     if (name) {
         /* Parent name is included if it is not the root and the datatype is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((new_datatype->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(new_datatype->handle_path, parent->handle_path, strlen(parent->handle_path));
@@ -392,12 +393,13 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
 
     if (name) {
         /* Parent name is included if it is not the root and the datatype is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((datatype->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(datatype->handle_path, parent->handle_path, strlen(parent->handle_path));

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -126,30 +126,8 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
 
     new_datatype->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the datatype is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((new_datatype->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(new_datatype->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in datatype path */
-        if (name[0] != '/') {
-            new_datatype->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(new_datatype->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &new_datatype->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_PATH, NULL, "can't set up object path");
 
     /* Copy the TAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * datatype access property list functions will function correctly
@@ -396,30 +374,8 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
 
     datatype->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the datatype is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((datatype->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(datatype->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in datatype path */
-        if (name[0] != '/') {
-            datatype->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(datatype->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &datatype->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_PATH, NULL, "can't set up object path");
 
     loc_info_out.URI         = datatype->URI;
     loc_info_out.domain      = datatype->domain;

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -76,7 +76,7 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     new_file->u.file.fapl_id       = FAIL;
     new_file->u.file.fcpl_id       = FAIL;
     new_file->u.file.ref_count     = 1;
-    new_file->handle_path = "/";
+    new_file->handle_path          = "/";
 
     /* Copy the FAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Fget_access_plist() will function correctly. Note that due to the nature
@@ -344,8 +344,8 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     file->u.file.fapl_id       = FAIL;
     file->u.file.fcpl_id       = FAIL;
     file->u.file.ref_count     = 1;
-    file->handle_path = "/";
-    
+    file->handle_path          = "/";
+
     /* Store self-referential pointer in the domain field for this object
      * to simplify code for other types of objects
      */

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -76,6 +76,7 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     new_file->u.file.fapl_id       = FAIL;
     new_file->u.file.fcpl_id       = FAIL;
     new_file->u.file.ref_count     = 1;
+    new_file->handle_path = "/";
 
     /* Copy the FAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Fget_access_plist() will function correctly. Note that due to the nature
@@ -343,7 +344,8 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     file->u.file.fapl_id       = FAIL;
     file->u.file.fcpl_id       = FAIL;
     file->u.file.ref_count     = 1;
-
+    file->handle_path = "/";
+    
     /* Store self-referential pointer in the domain field for this object
      * to simplify code for other types of objects
      */

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -76,7 +76,7 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     new_file->u.file.fapl_id       = FAIL;
     new_file->u.file.fcpl_id       = FAIL;
     new_file->u.file.ref_count     = 1;
-    
+
     /* Allocate root "path" on heap for consistency with other RV_object_t types */
     if ((new_file->handle_path = RV_malloc(2)) == NULL)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -76,7 +76,7 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     new_file->u.file.fapl_id       = FAIL;
     new_file->u.file.fcpl_id       = FAIL;
     new_file->u.file.ref_count     = 1;
-
+    
     /* Allocate root "path" on heap for consistency with other RV_object_t types */
     if ((new_file->handle_path = RV_malloc(2)) == NULL)
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");
@@ -355,7 +355,6 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");
 
     strncpy(file->handle_path, "/", 2);
-
 
     /* Store self-referential pointer in the domain field for this object
      * to simplify code for other types of objects
@@ -741,7 +740,11 @@ RV_file_close(void *file, hid_t dxpl_id, void **req)
             _file->u.file.filepath_name = NULL;
         }
 
-        RV_free(_file->handle_path);
+        if (_file->handle_path) {
+            RV_free(_file->handle_path);
+            _file->handle_path = NULL;
+        }
+
         RV_free(_file);
     }
 

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -76,7 +76,12 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     new_file->u.file.fapl_id       = FAIL;
     new_file->u.file.fcpl_id       = FAIL;
     new_file->u.file.ref_count     = 1;
-    new_file->handle_path          = "/";
+
+    /* Allocate root "path" on heap for consistency with other RV_object_t types */
+    if ((new_file->handle_path = RV_malloc(2)) == NULL)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");
+
+    strncpy(new_file->handle_path, "/", 2);
 
     /* Copy the FAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * H5Fget_access_plist() will function correctly. Note that due to the nature
@@ -344,7 +349,13 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     file->u.file.fapl_id       = FAIL;
     file->u.file.fcpl_id       = FAIL;
     file->u.file.ref_count     = 1;
-    file->handle_path          = "/";
+
+    /* Allocate root "path" on heap for consistency with other RV_object_t types */
+    if ((file->handle_path = RV_malloc(2)) == NULL)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for filepath");
+
+    strncpy(file->handle_path, "/", 2);
+
 
     /* Store self-referential pointer in the domain field for this object
      * to simplify code for other types of objects
@@ -730,6 +741,7 @@ RV_file_close(void *file, hid_t dxpl_id, void **req)
             _file->u.file.filepath_name = NULL;
         }
 
+        RV_free(_file->handle_path);
         RV_free(_file);
     }
 

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -47,8 +47,8 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     size_t       host_header_len       = 0;
     size_t       base64_buf_size       = 0;
     size_t       plist_nalloc          = 0;
-    size_t path_size = 0;
-    size_t path_len = 0;
+    size_t       path_size             = 0;
+    size_t       path_len              = 0;
     char        *host_header           = NULL;
     char        *create_request_body   = NULL;
     char        *path_dirname          = NULL;
@@ -98,12 +98,13 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     if (name) {
         /* Parent name is included if it is not the root and the group is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((new_group->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(new_group->handle_path, parent->handle_path, strlen(parent->handle_path));
@@ -120,7 +121,6 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
         path_len += (strlen(name) + 1);
     }
 
-    
     /* Copy the GAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * group access property list functions will function correctly
      */
@@ -366,11 +366,11 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name, 
     htri_t       search_ret;
     void        *ret_value = NULL;
     // char        *base64_binary_gcpl = NULL;
-    void   *binary_gcpl      = NULL;
-    size_t *binary_gcpl_size = 0;
-    size_t path_size = 0;
-    size_t path_len = 0;
-    H5I_type_t obj_type = H5I_UNINIT;
+    void      *binary_gcpl      = NULL;
+    size_t    *binary_gcpl_size = 0;
+    size_t     path_size        = 0;
+    size_t     path_len         = 0;
+    H5I_type_t obj_type         = H5I_UNINIT;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received group open call with following parameters:\n");
@@ -404,12 +404,13 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name, 
 
     if (name) {
         /* Parent name is included if it is not the root and the group is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/'); 
+        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
 
-        path_size = (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-        
+        path_size =
+            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
+
         if ((group->handle_path = RV_malloc(path_size)) == NULL)
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
+            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
 
         if (include_parent_name) {
             strncpy(group->handle_path, parent->handle_path, strlen(parent->handle_path));

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -96,30 +96,8 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     new_group->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the group is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((new_group->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(new_group->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in group name */
-        if (name[0] != '/') {
-            new_group->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(new_group->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &new_group->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_SYM, H5E_PATH, NULL, "can't set up object path");
 
     /* Copy the GAPL if it wasn't H5P_DEFAULT, else set up a default one so that
      * group access property list functions will function correctly
@@ -402,30 +380,8 @@ RV_group_open(void *obj, const H5VL_loc_params_t *loc_params, const char *name, 
 
     group->handle_path = NULL;
 
-    if (name) {
-        /* Parent name is included if it is not the root and the group is opened by relative path */
-        hbool_t include_parent_name = strcmp(parent->handle_path, "/") && (name[0] != '/');
-
-        path_size =
-            (include_parent_name ? strlen(parent->handle_path) + 1 + strlen(name) + 1 : 1 + strlen(name) + 1);
-
-        if ((group->handle_path = RV_malloc(path_size)) == NULL)
-            FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for handle path");
-
-        if (include_parent_name) {
-            strncpy(group->handle_path, parent->handle_path, strlen(parent->handle_path));
-            path_len += strlen(parent->handle_path);
-        }
-
-        /* Add leading slash if not in group name */
-        if (name[0] != '/') {
-            group->handle_path[path_len] = '/';
-            path_len += 1;
-        }
-
-        strncpy(group->handle_path + path_len, name, strlen(name) + 1);
-        path_len += (strlen(name) + 1);
-    }
+    if (RV_set_object_handle_path(name, parent->handle_path, &group->handle_path) < 0)
+        FUNC_GOTO_ERROR(H5E_SYM, H5E_PATH, NULL, "can't set up object path");
 
     /* Locate group and set domain */
 

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -1799,7 +1799,8 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
                     subgroup->obj_type        = H5I_GROUP;
                     subgroup->u.group.gcpl_id = H5P_DEFAULT;
                     subgroup->u.group.gapl_id = H5P_DEFAULT;
-                    if (RV_set_object_handle_path(link_name, object_iter_data->iter_obj_parent->handle_path, &subgroup->handle_path) < 0)
+                    if (RV_set_object_handle_path(link_name, object_iter_data->iter_obj_parent->handle_path,
+                                                  &subgroup->handle_path) < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "can't set up object path");
 
                     object_iter_data->iter_obj_parent->domain->u.file.ref_count++;

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -277,22 +277,25 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     switch (args->op_type) {
         case H5VL_OBJECT_GET_NAME: {
             size_t copy_size = 0;
-            char *name = loc_obj->handle_path;
+            char  *name      = loc_obj->handle_path;
 
             if (!name)
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "object has NULL name");
-            
+
             /* Only return the name if the user provided an allocate buffer */
             if (args->args.get_name.buf) {
                 /* Initialize entire buffer regardless of path size */
                 memset(args->args.get_name.buf, 0, args->args.get_name.buf_size);
 
-                /* If given an attribute, H5Iget_name returns the name of the object an attribute is attached to */
+                /* If given an attribute, H5Iget_name returns the name of the object an attribute is attached
+                 * to */
                 if (loc_obj->obj_type == H5I_ATTR)
                     if ((name = loc_obj->u.attribute.parent_name) == NULL)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "attribute parent has NULL name");
 
-                copy_size = (strlen(name) < args->args.get_name.buf_size - 1) ? strlen(name) : args->args.get_name.buf_size - 1;
+                copy_size = (strlen(name) < args->args.get_name.buf_size - 1)
+                                ? strlen(name)
+                                : args->args.get_name.buf_size - 1;
                 strncpy(args->args.get_name.buf, name, copy_size);
                 args->args.get_name.buf[copy_size + 1] = '\0';
             }
@@ -301,8 +304,7 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                 *args->args.get_name.name_len = strlen(name);
             }
 
-        }
-            break;
+        } break;
         case H5VL_OBJECT_GET_FILE:
         case H5VL_OBJECT_GET_TYPE:
             FUNC_GOTO_ERROR(H5E_OBJECT, H5E_UNSUPPORTED, FAIL, "unsupported object operation");

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -313,7 +313,6 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                                 ? strlen(name)
                                 : args->args.get_name.buf_size - 1;
                 strncpy(args->args.get_name.buf, name, copy_size);
-                args->args.get_name.buf[copy_size + 1] = '\0';
             }
 
             if (args->args.get_name.name_len) {
@@ -813,7 +812,7 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
                     /* Increment refs for top-level file */
                     loc_obj->domain->u.file.ref_count++;
 
-                    if ((iter_object = RV_malloc(sizeof(RV_object_t))) == NULL)
+                    if ((iter_object = RV_calloc(sizeof(RV_object_t))) == NULL)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTALLOC, FAIL,
                                         "couldn't allocate space for iteration object");
 


### PR DESCRIPTION
Associating a path/name with each open object goes against the spirit
of the API, but the alternative is traversing every link in the
domain, which is already slow in the library and would be
slower here.