### PR TITLE
Fix build_vol_cmake.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,8 @@ include (${HDF5_VOL_REST_RESOURCES_DIR}/HDFCompilerFlags.cmake)
 # a pre-built HDF5 distribution
 #-----------------------------------------------------------------------------
 if (NOT PREBUILT_HDF5_DIR)
+  include_directories(${HDF5_VOL_REST_SRC_DIR}/${HDF5_DIR_NAME}/src)
+  include_directories(${HDF5_VOL_REST_SRC_DIR}/${HDF5_DIR_NAME}/src/H5FDsubfiling)
   add_subdirectory(${HDF5_DIR} ${PROJECT_BINARY_DIR}/${HDF5_DIR_NAME})
 else ()
   link_directories(${PREBUILT_HDF5_DIR}/lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ if (PREBUILT_HDF5_DIR)
 else ()
   add_custom_target(
     rest_vol_pubconf_depend
-    DEPENDS ${CMAKE_BINARY_DIR}/${HDF5_DIR_NAME}/H5pubconf.h
+    DEPENDS ${CMAKE_BINARY_DIR}/${HDF5_DIR_NAME}/src/H5pubconf.h
   )
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vol-tests/CMakeLists.txt)
   )
   message(STATUS ${GIT_SUBMODULE_UPDATE_OUTPUT})
 endif()
-add_subdirectory(vol-tests)
+#add_subdirectory(vol-tests)
 
 #-----------------------------------------------------------------------------
 # REST VOL specific tests


### PR DESCRIPTION
vol-tests' configuration requires HDF5 to be built, so the script
now configures and builds the REST VOL/HDF5 before
configuring/building vol-tests.

The instructions for manual build with cmake will
eventually need to be updated for anyone who wants
to build the vol-tests as well.

