### PR TITLE
build_vol_cmake.sh: (fix) -G flag

### DIFF
--- a/build_vol_cmake.sh
+++ b/build_vol_cmake.sh
@@ -96,7 +96,7 @@ usage()
     echo
 }
 
-optspec=":hctdmst:H:C:Y:B:P:-"
+optspec=":hctdmstG:H:C:Y:B:P:-"
 while getopts "$optspec" optchar; do
     case "${optchar}" in
     h)


### PR DESCRIPTION
- Re-introduced the -G flag in the optspec variable which I accidentally removed in a previous commit.