### PR TITLE
Implement H5Dget_storage_size

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -136,6 +136,9 @@ const char *link_collection_keys2[] = {"collection", (const char *)0};
 
 const char *attributes_keys[] = {"attributes", (const char *)0};
 
+/* JSON keys to retrieve allocated size */
+const char *allocated_size_keys[] = {"allocated_size", (const char *)0};
+
 /* Default size for the buffer to allocate during base64-encoding if the caller
  * of RV_base64_encode supplies a 0-sized buffer.
  */
@@ -3329,6 +3332,45 @@ RV_parse_server_version(char *HTTP_response, void *callback_data_in, void *callb
 
     server_version->patch = (size_t)numeric_version_field;
 
+done:
+    if (parse_tree)
+        yajl_tree_free(parse_tree);
+
+    return ret_value;
+}
+
+/* Helper function to parse an object's allocated size from server response */
+herr_t
+RV_parse_allocated_size_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+{
+    yajl_val parse_tree = NULL, key_obj = NULL;
+    herr_t   ret_value      = SUCCEED;
+    size_t  *allocated_size = (size_t *)callback_data_out;
+
+#ifdef RV_CONNECTOR_DEBUG
+    printf("-> Retrieving allocated size from server's HTTP response\n\n");
+#endif
+
+    if (!HTTP_response)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "HTTP response buffer was NULL");
+
+    if (!allocated_size)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "allocated size pointer was NULL");
+
+    if (NULL == (parse_tree = yajl_tree_parse(HTTP_response, NULL, 0)))
+        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsing JSON failed");
+
+    /* Retrieve size */
+    if (NULL == (key_obj = yajl_tree_get(parse_tree, allocated_size_keys, yajl_t_number)))
+        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "failed to parse allocated size");
+
+    if (!YAJL_IS_INTEGER(key_obj))
+        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "parsed allocated size is not an integer");
+
+    if (YAJL_GET_INTEGER(key_obj) < 0)
+        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "parsed allocated size was negative");
+
+    *allocated_size = (size_t)YAJL_GET_INTEGER(key_obj);
 done:
     if (parse_tree)
         yajl_tree_free(parse_tree);

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -631,6 +631,9 @@ herr_t RV_set_object_handle_path(const char *obj_path, const char *parent_path, 
 /* Helper to turn an object type into a string for a server request */
 herr_t RV_set_object_type_header(H5I_type_t parent_obj_type, const char **parent_obj_type_header);
 
+/* Helper function to parse an object's allocated size from server response */
+herr_t RV_parse_allocated_size_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
+
 void RV_free_visited_link_hash_table_key(rv_hash_table_key_t value);
 
 #define SERVER_VERSION_MATCHES_OR_EXCEEDS(version, major_needed, minor_needed, patch_needed)                 \

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -1000,6 +1000,10 @@ RV_dataset_get(void *obj, H5VL_dataset_get_args_t *args, hid_t dxpl_id, void **r
     RV_object_t *dset      = (RV_object_t *)obj;
     herr_t       ret_value = SUCCEED;
 
+    size_t host_header_len = 0;
+    char  *host_header     = NULL;
+    char   request_url[URL_MAX_LENGTH];
+
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received dataset get call with following parameters:\n");
     printf("     - Dataset get call type: %s\n", dataset_get_type_to_string(args->op_type));
@@ -1049,7 +1053,43 @@ RV_dataset_get(void *obj, H5VL_dataset_get_args_t *args, hid_t dxpl_id, void **r
 
         /* H5Dget_storage_size */
         case H5VL_DATASET_GET_STORAGE_SIZE:
-            FUNC_GOTO_ERROR(H5E_DATASET, H5E_UNSUPPORTED, FAIL, "H5Dget_storage_size is unsupported");
+
+            /* Make GET request to dataset with 'verbose' parameter for HSDS. */
+            snprintf(request_url, URL_MAX_LENGTH, "%s%s%s%s", base_URL, "/datasets/", dset->URI,
+                     "?verbose=1");
+
+            /* Setup the host header */
+            host_header_len = strlen(dset->domain->u.file.filepath_name) + strlen(host_string) + 1;
+            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL,
+                                "can't allocate space for request Host header");
+
+            strcpy(host_header, host_string);
+
+            curl_headers =
+                curl_slist_append(curl_headers, strncat(host_header, dset->domain->u.file.filepath_name,
+                                                        host_header_len - strlen(host_string) - 1));
+
+            /* Disable use of Expect: 100 Continue HTTP response */
+            curl_headers = curl_slist_append(curl_headers, "Expect:");
+
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
+                                curl_err_buf);
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL,
+                                "can't set up cURL to make HTTP GET request: %s", curl_err_buf);
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
+                                curl_err_buf);
+
+            CURL_PERFORM(curl, H5E_DATASET, H5E_CANTGET, FAIL);
+
+            if (RV_parse_allocated_size_callback(response_buffer.buffer, NULL,
+                                                 args->args.get_storage_size.storage_size) < 0)
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_PARSEERROR, FAIL,
+                                "can't get allocated size from server response");
+
             break;
 
         /* H5Dget_type */
@@ -1068,6 +1108,13 @@ RV_dataset_get(void *obj, H5VL_dataset_get_args_t *args, hid_t dxpl_id, void **r
     } /* end switch */
 
 done:
+    if (curl_headers) {
+        curl_slist_free_all(curl_headers);
+        curl_headers = NULL;
+    }
+
+    RV_free(host_header);
+
     PRINT_ERROR_STACK;
 
     return ret_value;


### PR DESCRIPTION
As of HSDS 0.8.2, HSDS only updates its count of how large each file is every minute or so by default, so this function may return inaccurate values for recently modified files (see HDFGroup/hsds#255)