### PR TITLE
Implement H5Fflush

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -84,6 +84,8 @@
 #define HTTP_SERVER_ERROR_MIN 500 /* Minimum and maximum values for the 500 class of */
 #define HTTP_SERVER_ERROR_MAX 599 /* HTTP server error responses */
 
+#define HTTP_NO_CONTENT 204 /* HTTP server code for 'No Content' response */
+
 /* Macros to check for various classes of HTTP response */
 #define HTTP_INFORMATIONAL(status_code)                                                                      \
     (status_code >= HTTP_INFORMATIONAL_MIN && status_code <= HTTP_INFORMATIONAL_MAX)

--- a/test/test_rest_vol.c
+++ b/test/test_rest_vol.c
@@ -1471,8 +1471,6 @@ test_unused_file_API_calls(void)
         hid_t               obj_id;
         void               *file_handle;
 
-        if (H5Fflush(file_id, H5F_SCOPE_GLOBAL) >= 0)
-            TEST_ERROR
         if (H5Fget_obj_count(file_id, H5F_OBJ_DATASET) >= 0)
             TEST_ERROR
         if (H5Fget_obj_ids(file_id, H5F_OBJ_DATASET, 0, &obj_id) >= 0)


### PR DESCRIPTION
Ignores the H5F_SCOPE_GLOBAL/H5F_SCOPE_LOCAL parameter, since file mounting isn't implemented in HSDS.