### PR TITLE
Add min curl version to README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if (NOT PREBUILT_HDF5_DIR)
   endif ()
 endif ()
 
-find_package (CURL REQUIRED)
+find_package (CURL 7.61 REQUIRED)
 if (CURL_FOUND)
   include_directories(${CURL_INCLUDE_DIRS})
   set (LINK_LIBS ${LINK_LIBS} ${CURL_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To build the REST VOL connector, the following libraries are required:
             connector. Using statically-built HDF5 libraries can cause issues with the REST
             VOL connector under certain circumstances.
 
-+ libcurl - networking support
++ libcurl (ver. 7.61.0 or greater) - networking support
     + https://curl.haxx.se/
 
 + libyajl (ver. 2.0.4 or greater) - JSON parsing and construction


### PR DESCRIPTION
For #67 

Specifically, 7.61.0 is required due to the use of [CURLAUTH_BEARER](https://curl.se/libcurl/c/CURLOPT_HTTPAUTH.html)