### PR TITLE
CMake: (feature) YAJL version number

### DIFF
--- a/CMake/FindYAJL.cmake
+++ b/CMake/FindYAJL.cmake
@@ -17,11 +17,25 @@ find_path(YAJL_INCLUDE_DIR yajl/yajl_version.h DOC "YAJL include directory")
 find_library(YAJL_SHARED_LIBRARY NAMES yajl libyajl DOC "Shared YAJL library")
 find_library(YAJL_STATIC_LIBRARY NAMES yajl_s libyajl_s DOC "Static YAJL library")
 
+# Version
+if (YAJL_INCLUDE_DIR)
+  file(STRINGS "${YAJL_INCLUDE_DIR}/yajl/yajl_version.h" YAJL_H REGEX "^#define YAJL_MAJOR ")
+  string(REGEX REPLACE "#define YAJL_MAJOR ([0-9]+).*$" "\\1" YAJL_MAJOR "${YAJL_H}")
+  file(STRINGS "${YAJL_INCLUDE_DIR}/yajl/yajl_version.h" YAJL_H REGEX "^#define YAJL_MINOR ")
+  string(REGEX REPLACE "#define YAJL_MINOR ([0-9]+).*$" "\\1" YAJL_MINOR "${YAJL_H}")
+  file(STRINGS "${YAJL_INCLUDE_DIR}/yajl/yajl_version.h" YAJL_H REGEX "^#define YAJL_MICRO ")
+  string(REGEX REPLACE "#define YAJL_MICRO ([0-9]+).*$" "\\1" YAJL_MICRO "${YAJL_H}")
+  set(YAJL_VERSION "${YAJL_MAJOR}.${YAJL_MINOR}.${YAJL_MICRO}")
+endif ()
+
+
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBYAJL_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(YAJL DEFAULT_MSG
-                                  YAJL_SHARED_LIBRARY YAJL_STATIC_LIBRARY YAJL_INCLUDE_DIR)
+find_package_handle_standard_args(YAJL
+  FOUND_VAR YAJL_FOUND
+  REQUIRED_VARS YAJL_SHARED_LIBRARY YAJL_STATIC_LIBRARY YAJL_INCLUDE_DIR
+  VERSION_VAR YAJL_VERSION)
 
 if (YAJL_FOUND)
   add_library(yajl-shared SHARED IMPORTED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ endif ()
 # Include custom module for finding YAJL
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${HDF5_VOL_REST_RESOURCES_MOD_DIR}")
 
-find_package (YAJL REQUIRED)
+find_package (YAJL 2.0.4 REQUIRED)
 if (YAJL_FOUND)
   include_directories(${YAJL_INCLUDE_DIRS})
   set (LINK_LIBS ${LINK_LIBS} yajl)


### PR DESCRIPTION
- Retrieve the YAJL version number of the header file.
- Enforce the minimum required YAJL version in the find_package() call.