### PR TITLE
Implement type conversion for simple numeric types

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -3527,8 +3527,9 @@ done:
 
 herr_t
 RV_curl_multi_perform(CURL *curl_multi_handle, dataset_transfer_info *transfer_info, size_t count,
-                      herr_t(success_callback)(hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_id,
-                                               void *buf, struct response_buffer resp_buffer))
+                      herr_t(success_callback)(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id,
+                                               hid_t file_space_id, void *buf,
+                                               struct response_buffer resp_buffer))
 {
 
     herr_t         ret_value               = SUCCEED;
@@ -3659,6 +3660,7 @@ RV_curl_multi_perform(CURL *curl_multi_handle, dataset_transfer_info *transfer_i
 
                     if (success_callback(
                             transfer_info[handle_index].mem_type_id, transfer_info[handle_index].mem_space_id,
+                            transfer_info[handle_index].file_type_id,
                             transfer_info[handle_index].file_space_id, transfer_info[handle_index].buf,
                             transfer_info[handle_index].resp_buffer) < 0)
                         FUNC_GOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL,

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -581,7 +581,12 @@ typedef struct dataset_transfer_info {
     hid_t        mem_type_id;
     hid_t        mem_space_id;
     hid_t        file_space_id;
+    hid_t        file_type_id;
     char        *selection_body;
+
+    /* Fields for type conversion */
+    void *tconv_buf;
+    void *bkg_buf;
 
     transfer_type_t transfer_type;
 
@@ -642,6 +647,13 @@ typedef struct loc_info {
     char        *GCPL_base64;
     RV_object_t *domain;
 } loc_info;
+
+/* Enum to indicate if the supplied read buffer can be used as a type conversion or background buffer */
+typedef enum {
+    RV_TCONV_REUSE_NONE,  /* Cannot reuse buffer */
+    RV_TCONV_REUSE_TCONV, /* Use buffer as type conversion buffer */
+    RV_TCONV_REUSE_BKG    /* Use buffer as background buffer */
+} RV_tconv_reuse_t;
 
 /****************************
  *                          *
@@ -718,8 +730,16 @@ void RV_free_visited_link_hash_table_key(rv_hash_table_key_t value);
  * and waits until all requests on it have finished before returning. */
 herr_t RV_curl_multi_perform(CURL *curl_multi_ptr, dataset_transfer_info *transfer_info, size_t count,
                              herr_t(success_callback)(hid_t mem_type_id, hid_t mem_space_id,
-                                                      hid_t file_space_id, void *buf,
+                                                      hid_t file_type_id, hid_t file_space_id, void *buf,
                                                       struct response_buffer resp_buffer));
+
+/* Dtermine if datatype conversion is necessary */
+htri_t RV_need_tconv(hid_t src_type_id, hid_t dst_type_id);
+
+/* Initialize variables and buffers used for type conversion */
+herr_t RV_tconv_init(hid_t src_type_id, size_t *src_type_size, hid_t dst_type_id, size_t *dst_type_size,
+                     size_t num_elem, hbool_t clear_tconv_buf, hbool_t dst_file, void **tconv_buf,
+                     void **bkg_buf, RV_tconv_reuse_t *reuse, hbool_t *fill_bkg);
 
 #define SERVER_VERSION_MATCHES_OR_EXCEEDS(version, major_needed, minor_needed, patch_needed)                 \
     (version.major > major_needed) || (version.major == major_needed && version.minor > minor_needed) ||     \

--- a/src/rest_vol_datatype.h
+++ b/src/rest_vol_datatype.h
@@ -29,6 +29,13 @@ herr_t RV_datatype_close(void *dt, hid_t dxpl_id, void **req);
 hid_t  RV_parse_datatype(char *type, hbool_t need_truncate);
 herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type_body_len, hbool_t nested);
 
+/* Determine whether datatype conversion is necessary between 'same' datatypes */
+static htri_t RV_detect_vl_vlstr_ref(hid_t type_id);
+
+/* Determine if a background buffer is needed for type conversion */
+static htri_t RV_need_bkg(hid_t src_type_id, hid_t dst_type_id, hbool_t dst_file, size_t *dst_type_size,
+                          hbool_t *fill_bkg);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Several of the helpers here are copied from [the DAOS VOL's datatype code](https://github.com/HDFGroup/vol-daos/blob/master/src/daos_vol_type.c).

Tests for this are implemented in HDFGroup/vol-tests#62.

Fix for #6