### PR TITLE
rest_vol_dataset: Correct treatment of dataspace types in is_contiguous() and convert_start_to_offset()

### DIFF
--- a/CMakeInstallation.cmake
+++ b/CMakeInstallation.cmake
@@ -272,7 +272,7 @@ if (NOT HDF5_VOL_REST_NO_PACKAGES)
       set (CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES")
       set (CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
     endif ()
-    # set the install/unistall icon used for the installer itself
+    # set the install/uninstall icon used for the installer itself
     # There is a bug in NSI that does not handle full unix paths properly.
     set (CPACK_NSIS_MUI_ICON "${HDF5_VOL_REST_RESOURCES_EXT_DIR}\\\\hdf.ico")
     set (CPACK_NSIS_MUI_UNIICON "${HDF5_VOL_REST_RESOURCES_EXT_DIR}\\\\hdf.ico")

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ include the flag `-H <dir>` where `dir` is the path to the HDF5 install prefix.
 
 NOTE: For those who are capable of using both build systems, the autotools build currently
 does not support out-of-tree builds. If the REST VOL source directory is used for an autotools
-build, it is important not to re-use the source directory for a later build using CMake.
+build, it is important not to reuse the source directory for a later build using CMake.
 This can cause build conflicts and result in strange and unexpected behavior.
 
 

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -4302,11 +4302,17 @@ RV_dataspace_selection_is_contiguous(hid_t space_id)
             break;
 
         case H5S_SEL_ALL:
+            FUNC_GOTO_DONE(TRUE);
+            break;
+
+        case H5S_SEL_NONE:
+            FUNC_GOTO_DONE(FALSE);
+            break;
+
         case H5S_SEL_ERROR:
         case H5S_SEL_N:
-        case H5S_SEL_NONE:
         default:
-            FUNC_GOTO_DONE(TRUE);
+            FUNC_GOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "specified unsupported dataspace type");
     } /* end switch */
 
 done:
@@ -4379,11 +4385,14 @@ RV_convert_start_to_offset(hid_t space_id)
             break;
 
         case H5S_SEL_ALL:
+        case H5S_SEL_NONE:
+            ret_value = 0;
+            break;
+
         case H5S_SEL_ERROR:
         case H5S_SEL_N:
-        case H5S_SEL_NONE:
         default:
-            ret_value = 0;
+            FUNC_GOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, -1, "specified unsupported dataspace type");
     } /* end switch */
 
 done:


### PR DESCRIPTION
rest_vol_dataset: (fix) is_contiguous() and offset
- Improved the function RV_dataspace_selection_is_contiguous() and
  RV_convert_start_to_offset at suggested in pull request https://github.com/HDFGroup/vol-rest/pull/58
  on Github. In short, now the switch statements handle the various
  dataspace types correctly.

General: (fix) Corrected typos
- Corrected a typo in the file README.md and CMakeInstallation.cmake
  such that codespell does not report any errors.