### PR TITLE
Set connection info even with non-default FAPL

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -39,7 +39,8 @@
  */
 hid_t H5_rest_id_g = H5I_UNINIT;
 
-static hbool_t H5_rest_initialized_g = FALSE;
+static hbool_t H5_rest_initialized_g                 = FALSE;
+static hbool_t H5_rest_connection_info_initialized_g = FALSE;
 
 /* Identifiers for HDF5's error API */
 hid_t H5_rest_err_stack_g                 = H5I_INVALID_HID;
@@ -713,6 +714,9 @@ H5_rest_set_connection_information(void)
     FILE             *config_file = NULL;
     herr_t            ret_value   = SUCCEED;
 
+    if (H5_rest_connection_info_initialized_g)
+        FUNC_GOTO_DONE(SUCCEED);
+
     memset(&ad_info, 0, sizeof(ad_info));
 
     /*
@@ -945,6 +949,7 @@ H5_rest_set_connection_information(void)
                         "must specify a base URL - please set HSDS_ENDPOINT environment variable or create a "
                         "config file");
 
+    H5_rest_connection_info_initialized_g = TRUE;
 done:
     if (config_file)
         fclose(config_file);

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -64,15 +64,8 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     printf("     - Default FAPL? %s\n\n", (H5P_FILE_ACCESS_DEFAULT == fapl_id) ? "yes" : "no");
 #endif
 
-    /*
-     * If the connector has been dynamically loaded, the FAPL used for
-     * creating the file will be a default FAPL, so we need to ensure
-     * that the connection information gets set.
-     */
-    if (fapl_id == H5P_FILE_ACCESS_DEFAULT)
-        if (H5_rest_set_connection_information() < 0)
-            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL,
-                            "can't set REST VOL connector connection information");
+    if (H5_rest_set_connection_information() < 0)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't set REST VOL connector connection information");
 
     if (fapl_id == H5I_INVALID_HID)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid FAPL");
@@ -340,15 +333,8 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     printf("     - Default FAPL? %s\n\n", (H5P_FILE_ACCESS_DEFAULT == fapl_id) ? "yes" : "no");
 #endif
 
-    /*
-     * If the connector has been dynamically loaded, the FAPL used for
-     * creating the file will be a default FAPL, so we need to ensure
-     * that the connection information gets set.
-     */
-    if (fapl_id == H5P_FILE_ACCESS_DEFAULT)
-        if (H5_rest_set_connection_information() < 0)
-            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL,
-                            "can't set REST VOL connector connection information");
+    if (H5_rest_set_connection_information() < 0)
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "can't set REST VOL connector connection information");
 
     if (fapl_id == H5I_INVALID_HID)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid FAPL");


### PR DESCRIPTION
h5py uses a dynamically loaded connector while providing a non-default FAPL, and still needs the connection info to be set.

I tested this with a manually linked program, and didn't find any issues.