### PR TITLE
Flush domain before requesting allocated bytes

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -725,8 +725,11 @@ herr_t RV_curl_multi_perform(CURL *curl_multi_ptr, dataset_transfer_info *transf
     (version.major > major_needed) || (version.major == major_needed && version.minor > minor_needed) ||     \
         (version.major == major_needed && version.minor == minor_needed && version.patch >= patch_needed)
 
-#define SERVER_VERISON_SUPPORTS_FILL_VALUE_ENCODING(version)                                                 \
+#define SERVER_VERSION_SUPPORTS_FILL_VALUE_ENCODING(version)                                                 \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 1))
+
+#define SERVER_VERSION_SUPPORTS_GET_STORAGE_SIZE(version)                                                    \
+    (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
 
 #ifdef __cplusplus
 }

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -659,7 +659,7 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
              * the containing domain. */
             RV_object_t *target_domain = file->domain;
             filename                   = target_domain->u.file.filepath_name;
-            const char *flush_string   = "/?flush=1";
+            const char *flush_string   = "/?flush=1&rescan=1";
 
             name_length = strlen(filename);
 


### PR DESCRIPTION
Without this, if the size of the dataset changed in the last minute or so, get storage size is very likely to return an incorrect value.

Requires HDFGroup/hsds#269 in order to work, so it checks for the next (currently unreleased) version of HSDS. 