### PR TITLE
Silence compiler warnings

### DIFF
--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -18,14 +18,17 @@
 #include "rest_vol_attr.h"
 
 /* Set of callbacks for RV_parse_response() */
-static herr_t RV_get_attr_info_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
-static herr_t RV_attr_iter_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
+static herr_t RV_get_attr_info_callback(char *HTTP_response, const void *callback_data_in,
+                                        void *callback_data_out);
+static herr_t RV_attr_iter_callback(char *HTTP_response, const void *callback_data_in,
+                                    void *callback_data_out);
 
 /* Helper functions to work with a table of attributes for attribute iteration */
 static herr_t RV_build_attr_table(char *HTTP_response, hbool_t                                     sort,
                                   int (*sort_func)(const void *, const void *), attr_table_entry **attr_table,
                                   size_t *num_entries);
-static herr_t RV_traverse_attr_table(attr_table_entry *attr_table, size_t num_entries, iter_data *iter_data);
+static herr_t RV_traverse_attr_table(attr_table_entry *attr_table, size_t num_entries,
+                                     const iter_data *iter_data);
 
 /* Qsort callback to sort attributes by creation order */
 static int cmp_attributes_by_creation_order(const void *attr1, const void *attr2);
@@ -216,7 +219,7 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
 
     /* Form the Datatype portion of the Attribute create request */
     if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
-                                    parent->domain->u.file.server_version) < 0)
+                                    parent->domain->u.file.server_info.version) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, NULL,
                         "can't convert attribute's datatype to JSON representation");
 
@@ -3145,7 +3148,7 @@ done:
  *              December, 2017
  */
 static herr_t
-RV_get_attr_info_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+RV_get_attr_info_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
     H5A_info_t *attr_info = (H5A_info_t *)callback_data_out;
     herr_t      ret_value = SUCCEED;
@@ -3183,10 +3186,10 @@ done:
  *              January, 2018
  */
 static herr_t
-RV_attr_iter_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+RV_attr_iter_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
     attr_table_entry *attr_table     = NULL;
-    iter_data        *attr_iter_data = (iter_data *)callback_data_in;
+    const iter_data  *attr_iter_data = (const iter_data *)callback_data_in;
     size_t            attr_table_num_entries;
     herr_t            ret_value = SUCCEED;
 
@@ -3384,7 +3387,7 @@ done:
  *              January, 2018
  */
 static herr_t
-RV_traverse_attr_table(attr_table_entry *attr_table, size_t num_entries, iter_data *attr_iter_data)
+RV_traverse_attr_table(attr_table_entry *attr_table, size_t num_entries, const iter_data *attr_iter_data)
 {
     size_t last_idx;
     herr_t callback_ret;

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -19,10 +19,10 @@
 #include <math.h>
 
 /* Set of callbacks for RV_parse_response() */
-static herr_t RV_parse_dataset_creation_properties_callback(char *HTTP_response, void *callback_data_in,
+static herr_t RV_parse_dataset_creation_properties_callback(char *HTTP_response, const void *callback_data_in,
                                                             void *callback_data_out);
 
-static herr_t RV_json_values_to_binary_callback(char *HTTP_response, void *callback_data_in,
+static herr_t RV_json_values_to_binary_callback(char *HTTP_response, const void *callback_data_in,
                                                 void *callback_data_out);
 
 /* Internal helper for RV_json_values_to_binary_callback */
@@ -51,12 +51,6 @@ static herr_t   RV_convert_obj_refs_to_buffer(const rv_obj_ref_t *ref_array, siz
 static herr_t   RV_convert_buffer_to_obj_refs(char *ref_buf, size_t ref_buf_len, rv_obj_ref_t **buf_out,
                                               size_t *buf_out_len);
 static hssize_t RV_convert_start_to_offset(hid_t space_id);
-
-/* Callbacks used for post-processing after a curl request succeeds */
-static herr_t rv_dataset_read_cb(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id,
-                                 hid_t file_space_id, void *buf, struct response_buffer resp_buffer);
-static herr_t rv_dataset_write_cb(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id,
-                                  hid_t file_space_id, void *buf, struct response_buffer resp_buffer);
 
 /* Struct for H5Dscatter's callback that allows it to scatter from a non-global response buffer */
 struct response_read_info {
@@ -551,7 +545,7 @@ RV_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spac
         transfer_info[i].u.read_info.sel_type     = H5S_SEL_ALL;
         transfer_info[i].transfer_type            = READ;
         transfer_info[i].dataset                  = (RV_object_t *)dset[i];
-        transfer_info[i].buf                      = buf[i];
+        transfer_info[i].u.read_info.buf          = buf[i];
         transfer_info[i].mem_space_id             = _mem_space_id[i];
         transfer_info[i].file_space_id            = _file_space_id[i];
         transfer_info[i].mem_type_id              = mem_type_id[i];
@@ -799,7 +793,7 @@ RV_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spac
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL,
                         "failed to set max concurrent streams for curl multi handle");
 
-    if (RV_curl_multi_perform(curl_multi_handle, transfer_info, count, rv_dataset_read_cb) < 0)
+    if (RV_curl_multi_perform(curl_multi_handle, transfer_info, count) < 0)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "failed to perform dataset write");
 
 done:
@@ -867,11 +861,11 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
     dataset_transfer_info *transfer_info       = NULL;
     CURL                  *curl_multi_handle   = NULL;
 
-    hbool_t needs_tconv    = FALSE;
-    size_t  file_type_size = 0;
-    size_t  mem_type_size  = 0;
-    hbool_t fill_bkg       = FALSE;
-    void   *buf_to_write   = NULL;
+    hbool_t     needs_tconv    = FALSE;
+    size_t      file_type_size = 0;
+    size_t      mem_type_size  = 0;
+    hbool_t     fill_bkg       = FALSE;
+    const void *buf_to_write   = NULL;
 
     if ((transfer_info = RV_calloc(count * sizeof(dataset_transfer_info))) == NULL)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "can't allocate space for dataset transfer info");
@@ -921,7 +915,7 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
         transfer_info[i].u.write_info.write_body            = NULL;
         transfer_info[i].u.write_info.base64_encoded_values = NULL;
         transfer_info[i].dataset                            = (RV_object_t *)dset[i];
-        transfer_info[i].buf                                = (void *)buf[i];
+        transfer_info[i].u.write_info.buf                   = buf[i];
         transfer_info[i].transfer_type                      = WRITE;
 
         transfer_info[i].mem_space_id             = _mem_space_id[i];
@@ -1054,7 +1048,9 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
 
             /* Perform type conversion on response values */
             memset(transfer_info[i].tconv_buf, 0, file_type_size * (size_t)mem_select_npoints);
-            memcpy(transfer_info[i].tconv_buf, transfer_info[i].buf,
+            memcpy(transfer_info[i].tconv_buf,
+                   (transfer_info[i].transfer_type == READ) ? transfer_info[i].u.read_info.buf
+                                                            : transfer_info[i].u.write_info.buf,
                    mem_type_size * (size_t)mem_select_npoints);
 
             if (H5Tconvert(transfer_info[i].mem_type_id, transfer_info[i].file_type_id,
@@ -1064,7 +1060,15 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
                                 "failed to convert file datatype to memory datatype");
         }
 
-        buf_to_write = (transfer_info[i].tconv_buf) ? transfer_info[i].tconv_buf : transfer_info[i].buf;
+        /* If type conversion was performed, write from conversion buffer. Otherwise, write from transfer
+         * buffer for this transfer type */
+        if (transfer_info[i].tconv_buf) {
+            buf_to_write = transfer_info[i].tconv_buf;
+        }
+        else {
+            buf_to_write = (transfer_info[i].transfer_type == READ) ? transfer_info[i].u.read_info.buf
+                                                                    : transfer_info[i].u.write_info.buf;
+        }
 
         /* Setup the size of the data being transferred and the data buffer itself (for non-simple
          * types like object references or variable length types)
@@ -1261,7 +1265,7 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTSET, FAIL,
                         "failed to set max concurrent streams in curl multi handle");
 
-    if (RV_curl_multi_perform(curl_multi_handle, transfer_info, count, rv_dataset_write_cb) < 0)
+    if (RV_curl_multi_perform(curl_multi_handle, transfer_info, count) < 0)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "failed to perform dataset write");
 
 done:
@@ -1788,7 +1792,7 @@ done:
  *              November, 2017
  */
 static herr_t
-RV_parse_dataset_creation_properties_callback(char *HTTP_response, void *callback_data_in,
+RV_parse_dataset_creation_properties_callback(char *HTTP_response, const void *callback_data_in,
                                               void *callback_data_out)
 {
     yajl_val      parse_tree         = NULL, creation_properties_obj, key_obj;
@@ -3690,7 +3694,7 @@ RV_setup_dataset_create_request_body(void *parent_obj, const char *name, hid_t t
 
     /* Form the Datatype portion of the Dataset create request */
     if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
-                                    pobj->domain->u.file.server_version) < 0)
+                                    pobj->domain->u.file.server_info.version) < 0)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL,
                         "can't convert dataset's datatype to JSON representation");
 
@@ -4519,8 +4523,8 @@ dataset_read_scatter_op(const void **src_buf, size_t *src_buf_bytes_used, void *
 } /* end dataset_read_scatter_op() */
 
 /* Callback to be passed to rv_curl_multi_perform, for execution upon successful cURL request */
-static herr_t
-rv_dataset_read_cb(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id, hid_t file_space_id, void *buf,
+herr_t
+RV_dataset_read_cb(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id, hid_t file_space_id, void *buf,
                    struct response_buffer resp_buffer)
 {
     herr_t      ret_value      = SUCCEED;
@@ -4663,15 +4667,6 @@ done:
         RV_free(bkg_buf);
 
     return ret_value;
-}
-
-/* Callback to be passed to rv_curl_multi_perform, for execution upon successful cURL request */
-static herr_t
-rv_dataset_write_cb(hid_t mem_type_id, hid_t mem_space_id, hid_t file_type_id, hid_t file_space_id, void *buf,
-                    struct response_buffer resp_buffer)
-{
-    herr_t ret_value = SUCCEED;
-    return SUCCEED;
 }
 
 /*-------------------------------------------------------------------------
@@ -4895,16 +4890,17 @@ done:
  * Return:      Non-negative on success/Negative on failure
  */
 static herr_t
-RV_json_values_to_binary_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+RV_json_values_to_binary_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
 
-    void   **out_buf    = (void **)callback_data_out;
-    hid_t    dtype_id   = *(hid_t *)callback_data_in;
-    yajl_val parse_tree = NULL, key_obj;
-    char    *parsed_string;
-    herr_t   ret_value    = SUCCEED;
-    void    *value_buffer = NULL;
-    size_t   dtype_size   = 0;
+    void      **out_buf    = (void **)callback_data_out;
+    const hid_t dtype_id   = *(const hid_t *)callback_data_in;
+    yajl_val    parse_tree = NULL, key_obj;
+    char       *parsed_string;
+    herr_t      ret_value    = SUCCEED;
+    void       *value_buffer = NULL;
+    size_t      dtype_size   = 0;
+    H5T_class_t dtype_class  = H5T_NO_CLASS;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Converting response JSON values to binary buffer\n\n");

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -158,7 +158,7 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
 
     /* Convert the datatype into JSON to be used in the request body */
     if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
-                                    parent->domain->u.file.server_version) < 0)
+                                    parent->domain->u.file.server_info.version) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, NULL, "can't convert datatype to JSON representation");
 
     /* If this is not a H5Tcommit_anon call, create a link for the Datatype

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -967,7 +967,7 @@ RV_iterate_copy_hid_cb(hid_t obj_id, void *udata)
     herr_t               ret_value               = H5_ITER_CONT;
     get_obj_ids_udata_t *iterate_cb_args         = (get_obj_ids_udata_t *)udata;
     char                *containing_filename     = NULL;
-    size_t               containing_filename_len = 0;
+    ssize_t              containing_filename_len = 0;
     H5I_type_t           id_type                 = H5I_UNINIT;
     htri_t               is_committed            = FALSE;
 
@@ -993,11 +993,11 @@ RV_iterate_copy_hid_cb(hid_t obj_id, void *udata)
         if ((containing_filename_len = H5Fget_name(obj_id, NULL, 0)) < 0)
             FUNC_GOTO_ERROR(H5E_CALLBACK, H5E_CANTGET, FAIL, "unable to get length of filename");
 
-        if ((containing_filename = RV_malloc(containing_filename_len + 1)) == NULL)
+        if ((containing_filename = RV_malloc((size_t)containing_filename_len + 1)) == NULL)
             FUNC_GOTO_ERROR(H5E_CALLBACK, H5E_CANTALLOC, FAIL, "can't allocate space for filename");
 
         /* Get name */
-        if (H5Fget_name(obj_id, containing_filename, containing_filename_len + 1) < 0)
+        if (H5Fget_name(obj_id, containing_filename, (size_t)containing_filename_len + 1) < 0)
             FUNC_GOTO_ERROR(H5E_CALLBACK, H5E_CANTGET, FAIL, "unable to get filename");
 
         if (!strcmp(iterate_cb_args->local_filename, containing_filename)) {

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -18,7 +18,7 @@
 #include "rest_vol_group.h"
 
 /* Set of callbacks for RV_parse_response() */
-static herr_t RV_get_group_info_callback(char *HTTP_response, void *callback_data_in,
+static herr_t RV_get_group_info_callback(char *HTTP_response, const void *callback_data_in,
                                          void *callback_data_out);
 
 /* JSON keys to retrieve the number of links in a group */
@@ -785,7 +785,7 @@ done:
  *              November, 2017
  */
 static herr_t
-RV_get_group_info_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out)
+RV_get_group_info_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
     H5G_info_t *group_info = (H5G_info_t *)callback_data_out;
     yajl_val    parse_tree = NULL, key_obj;

--- a/src/rest_vol_link.h
+++ b/src/rest_vol_link.h
@@ -32,9 +32,10 @@ herr_t RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get
 herr_t RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_specific_args_t *args,
                         hid_t dxpl_id, void **req);
 
-herr_t RV_get_link_info_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
-herr_t RV_get_link_val_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
-herr_t RV_get_link_obj_type_callback(char *HTTP_response, void *callback_data_in, void *callback_data_out);
+herr_t RV_get_link_info_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out);
+herr_t RV_get_link_val_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out);
+herr_t RV_get_link_obj_type_callback(char *HTTP_response, const void *callback_data_in,
+                                     void *callback_data_out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Mostly dealing with issues around the `const` qualifier. Some changes of note:
- The data in field for `RV_parse_callback` now has the `const` qualifier, so most callbacks now have a `const` qualifier on their data in field as well.
- Removed the use of a callback in `RV_multi_perform`, now just checks the transfer type and uses the read callback directly. Removed the empty write callback. 
-  Because the `get_link_val_callback` needed to modify the size of the in buffer,the size of the in buffer was paired with the buffer itself in a new struct, `get_link_val_out`.
- Renamed `RV_parse_type -> RV_parse_object_class` to distinguish it from `RV_parse_datataype`