### PR TITLE
Make server connection info file-local

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -375,11 +375,6 @@ extern struct curl_slist *curl_headers;
  */
 #define CURL_RESPONSE_BUFFER_DEFAULT_SIZE 1024
 
-/*
- * Saved copy of the base URL for operating on
- */
-extern char *base_URL;
-
 #ifdef RV_TRACK_MEM_USAGE
 /*
  * Counter to keep track of the currently allocated amount of bytes
@@ -502,7 +497,8 @@ typedef struct server_api_version {
     size_t patch;
 } server_api_version;
 
-// TODO
+/* Structure containing information to connect to and evaluate
+ * features of a server */
 typedef struct server_info_t {
     char              *username;
     char              *password;
@@ -519,10 +515,9 @@ typedef struct server_info_t {
 typedef struct RV_object_t RV_object_t;
 
 typedef struct RV_file_t {
-    unsigned intent;
-    unsigned ref_count;
-    char    *filepath_name;
-    /* TODO - Username/password in global curl handle are still used for now */
+    unsigned      intent;
+    unsigned      ref_count;
+    char         *filepath_name;
     server_info_t server_info;
     hid_t         fcpl_id;
     hid_t         fapl_id;

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -502,6 +502,14 @@ typedef struct server_api_version {
     size_t patch;
 } server_api_version;
 
+// TODO
+typedef struct server_info_t {
+    char              *username;
+    char              *password;
+    char              *base_URL;
+    server_api_version version;
+} server_info_t;
+
 /*
  * Definitions for the basic objects which the REST VOL uses
  * to represent various HDF5 objects internally. The base object
@@ -511,12 +519,13 @@ typedef struct server_api_version {
 typedef struct RV_object_t RV_object_t;
 
 typedef struct RV_file_t {
-    unsigned           intent;
-    unsigned           ref_count;
-    char              *filepath_name;
-    hid_t              fcpl_id;
-    hid_t              fapl_id;
-    server_api_version server_version;
+    unsigned intent;
+    unsigned ref_count;
+    char    *filepath_name;
+    /* TODO - Username/password in global curl handle are still used for now */
+    server_info_t server_info;
+    hid_t         fcpl_id;
+    hid_t         fapl_id;
 } RV_file_t;
 
 typedef struct RV_group_t {
@@ -677,8 +686,8 @@ typedef enum {
 extern "C" {
 #endif
 
-/* Function to set the connection information for the connector to connect to the server */
-herr_t H5_rest_set_connection_information(void);
+/* Function to set the connection information on a file for the connector to connect to the server */
+herr_t H5_rest_set_connection_information(server_info_t *server_info);
 
 /* Alternate, more portable version of the basename function which doesn't modify its argument */
 const char *H5_rest_basename(const char *path);

--- a/src/rest_vol_config.h.in
+++ b/src/rest_vol_config.h.in
@@ -126,13 +126,13 @@
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD
-# if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
-# endif
+#if defined __BIG_ENDIAN__
+#define WORDS_BIGENDIAN 1
+#endif
 #else
-# ifndef WORDS_BIGENDIAN
-#  undef WORDS_BIGENDIAN
-# endif
+#ifndef WORDS_BIGENDIAN
+#undef WORDS_BIGENDIAN
+#endif
 #endif
 
 /* Define to empty if `const' does not conform to ANSI C. */

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -1623,8 +1623,8 @@ RV_dataset_specific(void *obj, H5VL_dataset_specific_args_t *args, hid_t dxpl_id
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
 
-            if ((url_len =
-                     snprintf(request_url, URL_MAX_LENGTH, "%s/datasets/%s/shape", dset->domain->u.file.server_info.base_URL, dset->URI)) < 0)
+            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datasets/%s/shape",
+                                    dset->domain->u.file.server_info.base_URL, dset->URI)) < 0)
                 FUNC_GOTO_ERROR(H5E_DATASET, H5E_SYSERRSTR, FAIL, "snprintf error");
 
             if (url_len >= URL_MAX_LENGTH)

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -74,6 +74,7 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     size_t       datatype_body_len     = 0;
     size_t       path_size             = 0;
     size_t       path_len              = 0;
+    const char  *base_URL              = NULL;
     char        *host_header           = NULL;
     char        *commit_request_body   = NULL;
     char        *datatype_body         = NULL;
@@ -101,6 +102,9 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
 
     if (H5I_FILE != parent->obj_type && H5I_GROUP != parent->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object not a file or group");
+
+    if ((base_URL = parent->domain->u.file.server_info.base_URL) == NULL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object does not have valid server URL");
 
     /* Check for write access */
     if (!(parent->domain->u.file.intent & H5F_ACC_RDWR))

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -254,6 +254,12 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     printf("-> Datatype commit URL: %s\n\n", request_url);
 #endif
 
+    if (CURLE_OK !=
+        curl_easy_setopt(curl, CURLOPT_USERNAME, new_datatype->domain->u.file.server_info.username))
+        FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, NULL, "can't set cURL username: %s", curl_err_buf);
+    if (CURLE_OK !=
+        curl_easy_setopt(curl, CURLOPT_PASSWORD, new_datatype->domain->u.file.server_info.password))
+        FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_POST, 1))
@@ -392,8 +398,8 @@ RV_datatype_open(void *obj, const H5VL_loc_params_t *loc_params, const char *nam
     loc_info_out.GCPL_base64 = NULL;
 
     /* Locate datatype and set domain */
-    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_loc_info_callback, NULL,
-                                        &loc_info_out);
+    search_ret = RV_find_object_by_path(parent, name, &obj_type, RV_copy_object_loc_info_callback,
+                                        &datatype->domain->u.file.server_info, &loc_info_out);
     if (!search_ret || search_ret < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_PATH, NULL, "can't locate datatype by path");
 

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -149,7 +149,7 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, base_URL))
+    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, new_file->u.file.server_info.base_URL))
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
 
     /* Before making the actual request, check the file creation flags for
@@ -399,13 +399,13 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL username: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, file->u.file.server_info.password))
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
+    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, file->u.file.server_info.base_URL))
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
         FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set up cURL to make HTTP GET request: %s",
                         curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, base_URL))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Retrieving info for file open\n\n");
@@ -669,14 +669,15 @@ done:
 herr_t
 RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void **req)
 {
-    RV_object_t *file      = (RV_object_t *)obj;
-    herr_t       ret_value = SUCCEED;
-    size_t       host_header_len;
-    size_t       name_length;
-    long         http_response;
-    char        *host_header = NULL;
-    const char  *filename    = NULL;
-    char        *request_url = NULL;
+    RV_object_t   *file      = (RV_object_t *)obj;
+    herr_t         ret_value = SUCCEED;
+    size_t         host_header_len;
+    size_t         name_length;
+    long           http_response;
+    char          *host_header = NULL;
+    const char    *filename    = NULL;
+    char          *request_url = NULL;
+    server_info_t *server_info = NULL;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received file-specific call with following parameters:\n");
@@ -716,10 +717,12 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
-            if (NULL == (request_url = (char *)RV_malloc(strlen(flush_string) + strlen(base_URL) + 1)))
+            if (NULL == (request_url = (char *)RV_malloc(
+                             strlen(flush_string) + strlen(target_domain->u.file.server_info.base_URL) + 1)))
                 FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate space for request URL");
 
-            snprintf(request_url, URL_MAX_LENGTH, "%s%s", base_URL, flush_string);
+            snprintf(request_url, URL_MAX_LENGTH, "%s%s", target_domain->u.file.server_info.base_URL,
+                     flush_string);
 
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, file->u.file.server_info.username))
                 FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
@@ -804,18 +807,22 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
-            /* TODO - H5Fdelete doesn't receive a file handle, so the username/password can't be pulled from
-             * it */
-            /*
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME,
-            file->domain->u.file.server_info.username)) FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't
-            set cURL username: %s", curl_err_buf); if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD,
-            file->domain->u.file.server_info.password)) FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't
-            set cURL password: %s", curl_err_buf);
-            */
+            /* H5Fdelete doesn't receive a file handle, so the username/password must be pulled
+             * from environment for now */
+            if ((server_info = RV_calloc(sizeof(server_info_t))) == NULL)
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate space for server information");
+
+            if (H5_rest_set_connection_information(server_info) < 0)
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get server connection information");
+
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, server_info->username))
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, server_info->password))
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
+
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, base_URL))
+            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, server_info->base_URL))
                 FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
 
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE"))
@@ -854,6 +861,13 @@ done:
 
     if (request_url)
         RV_free(request_url);
+
+    if (server_info) {
+        RV_free(server_info->base_URL);
+        RV_free(server_info->username);
+        RV_free(server_info->password);
+        RV_free(server_info);
+    }
 
     return ret_value;
 } /* end RV_file_specific() */
@@ -909,25 +923,16 @@ RV_file_close(void *file, hid_t dxpl_id, void **req)
             _file->u.file.filepath_name = NULL;
         }
 
-        if (_file->u.file.server_info.username) {
-            RV_free(_file->u.file.server_info.username);
-            _file->u.file.server_info.username;
-        }
+        RV_free(_file->u.file.server_info.username);
+        RV_free(_file->u.file.server_info.password);
+        RV_free(_file->u.file.server_info.base_URL);
 
-        if (_file->u.file.server_info.password) {
-            RV_free(_file->u.file.server_info.password);
-            _file->u.file.server_info.password;
-        }
+        _file->u.file.server_info.username = NULL;
+        _file->u.file.server_info.password = NULL;
+        _file->u.file.server_info.base_URL = NULL;
 
-        if (_file->u.file.server_info.base_URL) {
-            RV_free(_file->u.file.server_info.base_URL);
-            _file->u.file.server_info.base_URL;
-        }
-
-        if (_file->handle_path) {
-            RV_free(_file->handle_path);
-            _file->handle_path = NULL;
-        }
+        RV_free(_file->handle_path);
+        _file->handle_path = NULL;
 
         if (RV_type_info_array_g[H5I_FILE])
             rv_hash_table_remove(RV_type_info_array_g[H5I_FILE]->table, (char *)_file);

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -49,6 +49,7 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     size_t       plist_nalloc          = 0;
     size_t       path_size             = 0;
     size_t       path_len              = 0;
+    const char  *base_URL              = NULL;
     char        *host_header           = NULL;
     char        *create_request_body   = NULL;
     char        *path_dirname          = NULL;
@@ -74,6 +75,9 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     if (H5I_FILE != parent->obj_type && H5I_GROUP != parent->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object not a file or group");
+
+    if ((base_URL = parent->domain->u.file.server_info.base_URL) == NULL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object does not have valid server URL");
 
     if (gapl_id == H5I_INVALID_HID)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid GAPL");
@@ -493,6 +497,7 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
     char        *host_header     = NULL;
     char         request_url[URL_MAX_LENGTH];
     int          url_len   = 0;
+    const char  *base_URL  = NULL;
     herr_t       ret_value = SUCCEED;
 
     loc_info loc_info_out;
@@ -505,6 +510,8 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
 
     if (H5I_FILE != loc_obj->obj_type && H5I_GROUP != loc_obj->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a group");
+    if ((base_URL = loc_obj->domain->u.file.server_info.base_URL) == NULL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent object does not have valid server URL");
 
     switch (args->op_type) {
         /* H5Gget_create_plist */

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -336,7 +336,12 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
     uinfo.buffer      = create_request_body;
     uinfo.buffer_size = (size_t)create_request_body_len;
     uinfo.bytes_sent  = 0;
-
+    if (CURLE_OK !=
+        curl_easy_setopt(curl, CURLOPT_USERNAME, new_link_loc_obj->domain->u.file.server_info.username))
+        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+    if (CURLE_OK !=
+        curl_easy_setopt(curl, CURLOPT_PASSWORD, new_link_loc_obj->domain->u.file.server_info.password))
+        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_UPLOAD, 1))
@@ -565,7 +570,12 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
 
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
-
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
@@ -658,6 +668,12 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
@@ -773,6 +789,12 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
@@ -942,6 +964,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE"))
@@ -1020,6 +1048,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
@@ -1165,6 +1199,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -121,10 +121,10 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
             new_link_loc_obj = (RV_object_t *)hard_link_target_obj;
     } /* end if */
 
-    if (new_link_loc_obj && ((base_URL = new_link_loc_obj->domain->u.file.server_info.base_URL) == NULL))
-        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "location object does not have valid server URL");
+    if (!new_link_loc_obj)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link location object is NULL");
 
-    if (!base_URL)
+    if ((base_URL = new_link_loc_obj->domain->u.file.server_info.base_URL) == NULL)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link creation requires valid server URL");
 
     /* Validate loc_id and check for write access on the file */

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -31,7 +31,8 @@ static herr_t RV_link_iter_callback(char *HTTP_response, void *callback_data_in,
 /* Helper functions to work with a table of links for link iteration */
 static herr_t RV_build_link_table(char *HTTP_response, hbool_t is_recursive,
                                   int (*sort_func)(const void *, const void *), link_table_entry **link_table,
-                                  size_t *num_entries, rv_hash_table_t *visited_link_table);
+                                  size_t *num_entries, rv_hash_table_t *visited_link_table,
+                                  const char *base_URL);
 static void   RV_free_link_table(link_table_entry *link_table, size_t num_entries);
 static herr_t RV_traverse_link_table(link_table_entry *link_table, size_t num_entries, iter_data *iter_data,
                                      const char *cur_link_rel_path);
@@ -74,6 +75,7 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
     size_t             create_request_nalloc = 0;
     size_t             host_header_len       = 0;
     void              *hard_link_target_obj;
+    const char        *base_URL            = NULL;
     char              *host_header         = NULL;
     char              *create_request_body = NULL;
     char               request_url[URL_MAX_LENGTH];
@@ -94,7 +96,6 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
     printf("     - Default LCPL? %s\n", (H5P_LINK_CREATE_DEFAULT == lcpl_id) ? "yes" : "no");
     printf("     - Default LAPL? %s\n\n", (H5P_LINK_ACCESS_DEFAULT == lapl_id) ? "yes" : "no");
 #endif
-
     if (lcpl_id == H5I_INVALID_HID)
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL, "invalid LCPL");
 
@@ -119,6 +120,12 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
         if (!new_link_loc_obj)
             new_link_loc_obj = (RV_object_t *)hard_link_target_obj;
     } /* end if */
+
+    if (new_link_loc_obj && ((base_URL = new_link_loc_obj->domain->u.file.server_info.base_URL) == NULL))
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "location object does not have valid server URL");
+
+    if (!base_URL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "link creation requires valid server URL");
 
     /* Validate loc_id and check for write access on the file */
     if (H5I_FILE != new_link_loc_obj->obj_type && H5I_GROUP != new_link_loc_obj->obj_type)
@@ -467,6 +474,7 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
     RV_object_t *loc_obj = (RV_object_t *)obj;
     hbool_t      empty_dirname;
     size_t       host_header_len       = 0;
+    const char  *base_URL              = NULL;
     char        *host_header           = NULL;
     char        *link_dir_name         = NULL;
     char        *url_encoded_link_name = NULL;
@@ -482,6 +490,9 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
     printf("     - Link loc_obj's object type: %s\n", object_type_to_string(loc_obj->obj_type));
     printf("     - Link loc_obj's domain path: %s\n\n", loc_obj->domain->u.file.filepath_name);
 #endif
+
+    if ((base_URL = loc_obj->domain->u.file.server_info.base_URL) == NULL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "location object does not have valid server URL");
 
     switch (args->op_type) {
         /* H5Lget_info */
@@ -628,7 +639,7 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
             by_idx_data.idx_p                      = &loc_params->loc_data.loc_by_idx.n;
             by_idx_data.iter_function.link_iter_op = NULL;
             by_idx_data.op_data                    = NULL;
-
+            by_idx_data.iter_obj_parent            = loc_obj;
             /*
              * Setup information to be passed back from link name retrieval callback
              */
@@ -866,6 +877,7 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
     size_t       host_header_len        = 0;
     hid_t        link_iter_group_id     = H5I_INVALID_HID;
     void        *link_iter_group_object = NULL;
+    const char  *base_URL               = NULL;
     char        *host_header            = NULL;
     char        *link_path_dirname      = NULL;
     char         temp_URI[URI_MAX_LENGTH];
@@ -884,6 +896,9 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
 
     if (H5I_FILE != loc_obj->obj_type && H5I_GROUP != loc_obj->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent object not a file or group");
+
+    if ((base_URL = loc_obj->domain->u.file.server_info.base_URL) == NULL)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "location object does not have valid server URL");
 
     switch (args->op_type) {
         /* H5Ldelete */
@@ -1090,6 +1105,7 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
             link_iter_data.idx_p                      = args->args.iterate.idx_p;
             link_iter_data.iter_function.link_iter_op = args->args.iterate.op;
             link_iter_data.op_data                    = args->args.iterate.op_data;
+            link_iter_data.iter_obj_parent            = loc_obj;
 
             if (!link_iter_data.iter_function.link_iter_op)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_LINKITERERROR, FAIL, "no link iteration function specified");
@@ -1666,7 +1682,8 @@ RV_get_link_name_by_idx_callback(char *HTTP_response, void *callback_data_in, vo
 #endif
 
     if (RV_build_link_table(HTTP_response, by_idx_data->is_recursive, link_table_sort_func, &link_table,
-                            &link_table_num_entries, NULL) < 0)
+                            &link_table_num_entries, NULL,
+                            by_idx_data->iter_obj_parent->domain->u.file.server_info.base_URL) < 0)
         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTBUILDLINKTABLE, FAIL, "can't build link table");
 
     /* Check to make sure the index given is within bounds */
@@ -1765,7 +1782,8 @@ RV_link_iter_callback(char *HTTP_response, void *callback_data_in, void *callbac
          */
         if (RV_build_link_table(HTTP_response, link_iter_data->is_recursive,
                                 H5_rest_cmp_links_by_creation_order_inc, &link_table, &link_table_num_entries,
-                                visited_link_table) < 0)
+                                visited_link_table,
+                                link_iter_data->iter_obj_parent->domain->u.file.server_info.base_URL) < 0)
             FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTBUILDLINKTABLE, FAIL, "can't build link table");
 
 #ifdef RV_CONNECTOR_DEBUG
@@ -1774,7 +1792,8 @@ RV_link_iter_callback(char *HTTP_response, void *callback_data_in, void *callbac
     } /* end if */
     else {
         if (RV_build_link_table(HTTP_response, link_iter_data->is_recursive, NULL, &link_table,
-                                &link_table_num_entries, visited_link_table) < 0)
+                                &link_table_num_entries, visited_link_table,
+                                link_iter_data->iter_obj_parent->domain->u.file.server_info.base_URL) < 0)
             FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTBUILDLINKTABLE, FAIL, "can't build link table");
     } /* end else */
 
@@ -1827,7 +1846,8 @@ done:
  */
 static herr_t
 RV_build_link_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func)(const void *, const void *),
-                    link_table_entry **link_table, size_t *num_entries, rv_hash_table_t *visited_link_table)
+                    link_table_entry **link_table, size_t *num_entries, rv_hash_table_t *visited_link_table,
+                    const char *base_URL)
 {
     link_table_entry *table      = NULL;
     yajl_val          parse_tree = NULL, key_obj;
@@ -2024,7 +2044,7 @@ RV_build_link_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func)(
 
                     if (RV_build_link_table(response_buffer.buffer, is_recursive, sort_func,
                                             &table[i].subgroup.subgroup_link_table,
-                                            &table[i].subgroup.num_entries, visited_link_table) < 0)
+                                            &table[i].subgroup.num_entries, visited_link_table, base_URL) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTBUILDLINKTABLE, FAIL,
                                         "can't build link table for subgroup '%s'", table[i].link_name);
 

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -421,9 +421,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                     /* loc_info_out.domain was copied at function start */
 
                     /* Locate group and set domain */
-                    search_ret =
-                        RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name, &obj_type,
-                                               RV_copy_object_loc_info_callback, NULL, &loc_info_out);
+                    search_ret = RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name,
+                                                        &obj_type, RV_copy_object_loc_info_callback,
+                                                        &loc_obj->domain->u.file.server_info, &loc_info_out);
                     if (!search_ret || search_ret < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "can't locate object by path");
 
@@ -521,9 +521,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                     /* loc_info_out.domain was copied at function start */
 
                     /* Locate group and set domain */
-                    search_ret =
-                        RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name, &obj_type,
-                                               RV_copy_object_loc_info_callback, NULL, &loc_info_out);
+                    search_ret = RV_find_object_by_path(loc_obj, loc_params->loc_data.loc_by_name.name,
+                                                        &obj_type, RV_copy_object_loc_info_callback,
+                                                        &loc_obj->domain->u.file.server_info, &loc_info_out);
                     if (!search_ret || search_ret < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "can't locate object by path");
 
@@ -532,8 +532,8 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
 
                     switch (loc_params->loc_data.loc_by_idx.idx_type) {
                         case (H5_INDEX_CRT_ORDER):
-                            if (SERVER_VERSION_MATCHES_OR_EXCEEDS(loc_obj->domain->u.file.server_version, 0,
-                                                                  8, 0)) {
+                            if (SERVER_VERSION_MATCHES_OR_EXCEEDS(loc_obj->domain->u.file.server_info.version,
+                                                                  0, 8, 0)) {
                                 request_idx_type = "&CreateOrder=1";
                             }
                             else {
@@ -580,6 +580,14 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "attribute open URL exceeded maximum URL size");
 
+                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME,
+                                                     loc_obj->domain->u.file.server_info.username))
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s",
+                                        curl_err_buf);
+                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD,
+                                                     loc_obj->domain->u.file.server_info.password))
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s",
+                                        curl_err_buf);
                     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
                                         curl_err_buf);
@@ -614,9 +622,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                         loc_info_out.GCPL_base64 = NULL;
                     }
 
-                    search_ret =
-                        RV_find_object_by_path(loc_obj, found_object_name, &obj_type,
-                                               RV_copy_object_loc_info_callback, NULL, &loc_info_out);
+                    search_ret = RV_find_object_by_path(loc_obj, found_object_name, &obj_type,
+                                                        RV_copy_object_loc_info_callback,
+                                                        &loc_obj->domain->u.file.server_info, &loc_info_out);
                     if (!search_ret || search_ret < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PATH, FAIL, "can't locate object by path");
 
@@ -657,6 +665,12 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
                                 curl_err_buf);
@@ -827,7 +841,7 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
                     /* Increment refs for specific type */
                     switch (loc_obj->obj_type) {
                         case H5I_FILE:
-                            /* Copy fapl, fcpl, and filepath name to new object */
+                            /* Copy plists, filepath, and server info to new object */
 
                             if (H5I_INVALID_HID ==
                                 (iter_object->u.file.fapl_id = H5Pcopy(loc_obj->u.file.fapl_id)))
@@ -842,6 +856,33 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
 
                             strncpy(iter_object->u.file.filepath_name, loc_obj->u.file.filepath_name,
                                     strlen(loc_obj->u.file.filepath_name) + 1);
+
+                            if ((iter_object->u.file.server_info.username =
+                                     RV_malloc(strlen(loc_obj->u.file.server_info.username) + 1)) == NULL)
+                                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL,
+                                                "can't allocate space for copied username");
+
+                            strncpy(iter_object->u.file.server_info.username,
+                                    loc_obj->u.file.server_info.username,
+                                    strlen(loc_obj->u.file.server_info.username) + 1);
+
+                            if ((iter_object->u.file.server_info.password =
+                                     RV_malloc(strlen(loc_obj->u.file.server_info.password) + 1)) == NULL)
+                                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL,
+                                                "can't allocate space for copied password");
+
+                            strncpy(iter_object->u.file.server_info.password,
+                                    loc_obj->u.file.server_info.password,
+                                    strlen(loc_obj->u.file.server_info.password) + 1);
+
+                            if ((iter_object->u.file.server_info.base_URL =
+                                     RV_malloc(strlen(loc_obj->u.file.server_info.base_URL) + 1)) == NULL)
+                                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL,
+                                                "can't allocate space for copied URL");
+
+                            strncpy(iter_object->u.file.server_info.base_URL,
+                                    loc_obj->u.file.server_info.base_URL,
+                                    strlen(loc_obj->u.file.server_info.base_URL) + 1);
 
                             /* This is a copy of the file, not a reference to the same memory */
                             loc_obj->domain->u.file.ref_count--;
@@ -1065,6 +1106,12 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
             /* Disable use of Expect: 100 Continue HTTP response */
             curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+            if (CURLE_OK !=
+                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
             if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
@@ -1796,6 +1843,18 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
                     /* Disable use of Expect: 100 Continue HTTP response */
                     curl_headers = curl_slist_append(curl_headers, "Expect:");
 
+                    if (CURLE_OK !=
+                        curl_easy_setopt(
+                            curl, CURLOPT_USERNAME,
+                            object_iter_data->iter_obj_parent->domain->u.file.server_info.username))
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s",
+                                        curl_err_buf);
+                    if (CURLE_OK !=
+                        curl_easy_setopt(
+                            curl, CURLOPT_PASSWORD,
+                            object_iter_data->iter_obj_parent->domain->u.file.server_info.password))
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s",
+                                        curl_err_buf);
                     if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
                                         curl_err_buf);


### PR DESCRIPTION
`H5Fdelete` doesn't receive any information about the file to delete besides its filename, so this may be impossible to completely refactor. 

The global info (username/password in the global curl handle, global `base_URL` variable) haven't been removed yet, but each request to server now uses a file-local username and password.