### PR TITLE
Support UTF-8 string datatype encoding

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -496,7 +496,7 @@ typedef struct {
 } upload_info;
 
 /* Structure that keeps track of semantic version. */
-typedef struct server_api_version {
+typedef struct {
     size_t major;
     size_t minor;
     size_t patch;
@@ -753,6 +753,10 @@ herr_t RV_tconv_init(hid_t src_type_id, size_t *src_type_size, hid_t dst_type_id
                      size_t num_elem, hbool_t clear_tconv_buf, hbool_t dst_file, void **tconv_buf,
                      void **bkg_buf, RV_tconv_reuse_t *reuse, hbool_t *fill_bkg);
 
+/* REST VOL Datatype helper */
+herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type_body_len, hbool_t nested,
+                                   server_api_version server_version);
+
 #define SERVER_VERSION_MATCHES_OR_EXCEEDS(version, major_needed, minor_needed, patch_needed)                 \
     (version.major > major_needed) || (version.major == major_needed && version.minor > minor_needed) ||     \
         (version.major == major_needed && version.minor == minor_needed && version.patch >= patch_needed)
@@ -761,6 +765,9 @@ herr_t RV_tconv_init(hid_t src_type_id, size_t *src_type_size, hid_t dst_type_id
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 1))
 
 #define SERVER_VERSION_SUPPORTS_GET_STORAGE_SIZE(version)                                                    \
+    (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
+
+#define SERVER_VERSION_SUPPORTS_FIXED_LENGTH_UTF8(version)                                                   \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
 
 #ifdef __cplusplus

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -211,7 +211,8 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
     /* Form the request body to give the new Attribute its properties */
 
     /* Form the Datatype portion of the Attribute create request */
-    if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE) < 0)
+    if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
+                                    parent->domain->u.file.server_version) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, NULL,
                         "can't convert attribute's datatype to JSON representation");
 

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -3586,7 +3586,8 @@ RV_setup_dataset_create_request_body(void *parent_obj, const char *name, hid_t t
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "dataset create request output buffer was NULL");
 
     /* Form the Datatype portion of the Dataset create request */
-    if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE) < 0)
+    if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
+                                    pobj->domain->u.file.server_version) < 0)
         FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL,
                         "can't convert dataset's datatype to JSON representation");
 

--- a/src/rest_vol_datatype.h
+++ b/src/rest_vol_datatype.h
@@ -26,8 +26,7 @@ herr_t RV_datatype_get(void *obj, H5VL_datatype_get_args_t *args, hid_t dxpl_id,
 herr_t RV_datatype_close(void *dt, hid_t dxpl_id, void **req);
 
 /* REST VOL Datatype helper functions */
-hid_t  RV_parse_datatype(char *type, hbool_t need_truncate);
-herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type_body_len, hbool_t nested);
+hid_t RV_parse_datatype(char *type, hbool_t need_truncate);
 
 /* Determine whether datatype conversion is necessary between 'same' datatypes */
 static htri_t RV_detect_vl_vlstr_ref(hid_t type_id);


### PR DESCRIPTION
Draft PR until HSDS supports fixed-length strings with UTF-8 encoding (HDFGroup/hsds#270) and this can be tested further. 

Fix for #82