### PR TITLE
Refactor cURL use into helper functions with local handles

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -41,7 +41,8 @@
  */
 hid_t H5_rest_id_g = H5I_UNINIT;
 
-static hbool_t H5_rest_initialized_g = FALSE;
+static hbool_t H5_rest_initialized_g      = FALSE;
+static hbool_t H5_rest_curl_initialized_g = FALSE;
 
 /* Identifiers for HDF5's error API */
 hid_t H5_rest_err_stack_g                 = H5I_INVALID_HID;
@@ -182,6 +183,9 @@ herr_t RV_get_index_of_matching_handle(dataset_transfer_info *transfer_info, siz
 
 /* Stub that throws an error when called */
 void *RV_wrap_get_object(const void *obj);
+
+/* Helper function that creates and sets some fields on a cURL handle. */
+CURL *RV_curl_setup_handle(server_info_t *server_info, char *err_buf);
 
 /* The REST VOL connector's class structure. */
 static const H5VL_class_t H5VL_rest_g = {
@@ -408,8 +412,10 @@ H5_rest_init(hid_t vipl_id)
 #endif
 
     /* Initialize cURL */
-    if (CURLE_OK != curl_global_init(CURL_GLOBAL_ALL))
+    if (!H5_rest_curl_initialized_g && (CURLE_OK != curl_global_init(CURL_GLOBAL_ALL)))
         FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't initialize cURL");
+
+    H5_rest_curl_initialized_g = true;
 
     if (NULL == (curl = curl_easy_init()))
         FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't initialize cURL easy handle");
@@ -897,6 +903,15 @@ H5_rest_set_connection_information(server_info_t *server_info)
 
             strcpy(server_info->base_URL, base_URL);
         }
+    }
+
+    /* TODO - Global curl handle is only used for dataset read/writes right now.
+     * Once that is removed, this will be unnecessary. */
+    if (username && password) {
+        if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, server_info->username))
+            FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
+        if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, server_info->password))
+            FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
     }
 
 done:
@@ -1994,17 +2009,14 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
 {
     RV_object_t       *external_file    = NULL;
     hbool_t            is_relative_path = FALSE;
-    size_t             host_header_len  = 0;
     H5L_info2_t        link_info;
     char              *url_encoded_link_name = NULL;
-    char              *host_header           = NULL;
     char              *path_dirname          = NULL;
     char              *tmp_link_val          = NULL;
     char              *url_encoded_path_name = NULL;
     const char        *ext_filename          = NULL;
     const char        *ext_obj_path          = NULL;
-    const char        *base_URL;
-    char               request_url[URL_MAX_LENGTH];
+    char               request_endpoint[URL_MAX_LENGTH];
     long               http_response;
     int                url_len = 0;
     server_api_version version;
@@ -2020,8 +2032,7 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
     if (H5I_FILE != parent_obj->obj_type && H5I_GROUP != parent_obj->obj_type &&
         H5I_DATATYPE != parent_obj->obj_type && H5I_DATASET != parent_obj->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent object not a file, group, datatype or dataset");
-    if ((base_URL = parent_obj->domain->u.file.server_info.base_URL) == NULL)
-        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent object does not have valid server URL");
+
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Finding object by path '%s' from parent object of type %s with URI %s\n\n", obj_path,
            object_type_to_string(parent_obj->obj_type), parent_obj->URI);
@@ -2085,8 +2096,8 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
         if (NULL == (url_encoded_path_name = H5_rest_url_encode_path(obj_path)))
             FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTENCODE, FAIL, "can't URL-encode object path");
 
-        if ((url_len = snprintf(request_url, URL_MAX_LENGTH,
-                                "%s/?h5path=%s%s%s&follow_soft_links=1&follow_external_links=1", base_URL,
+        if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH,
+                                "/?h5path=%s%s%s&follow_soft_links=1&follow_external_links=1",
                                 url_encoded_path_name, is_relative_path ? "&parent_id=" : "",
                                 is_relative_path ? parent_obj->URI : "")) < 0)
             FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
@@ -2135,7 +2146,7 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
             if (NULL == (url_encoded_link_name = curl_easy_escape(curl, H5_rest_basename(obj_path), 0)))
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTENCODE, FAIL, "can't URL-encode link name");
 
-            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s/links/%s", base_URL, pobj_URI,
+            if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/groups/%s/links/%s", pobj_URI,
                                     url_encoded_link_name)) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
         }
@@ -2153,8 +2164,8 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
 
             /* Handle the special case for the paths "." and "/" */
             if (!strcmp(obj_path, ".") || !strcmp(obj_path, "/")) {
-                if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/%s/%s", base_URL,
-                                        parent_obj_type_header, parent_obj->URI)) < 0)
+                if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s", parent_obj_type_header,
+                                        parent_obj->URI)) < 0)
                     FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
             }
             else {
@@ -2173,8 +2184,8 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
                  *  [base_URL]/[object_type]/?h5path=[path_name]
                  */
                 if ((url_len = snprintf(
-                         request_url, URL_MAX_LENGTH, "%s/%s/%s?%s%s%sh5path=%s", base_URL,
-                         parent_obj_type_header, (is_relative_path && is_group) ? parent_obj->URI : "",
+                         request_endpoint, URL_MAX_LENGTH, "/%s/%s?%s%s%sh5path=%s", parent_obj_type_header,
+                         (is_relative_path && is_group) ? parent_obj->URI : "",
                          (is_relative_path && !is_group) ? "grpid=" : "",
                          (is_relative_path && !is_group) ? parent_obj->URI : "",
                          (is_relative_path && !is_group) ? "&" : "", url_encoded_path_name)) < 0)
@@ -2186,51 +2197,17 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
     if (url_len >= URL_MAX_LENGTH)
         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "Request URL size exceeded maximum URL size");
 
-    /* Setup cURL for making GET requests */
+    http_response = RV_curl_get(&parent_obj->domain->u.file.server_info, request_endpoint,
+                                parent_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
 
-    /* Setup the host header */
-    host_header_len = strlen(parent_obj->domain->u.file.filepath_name) + strlen(host_string) + 1;
-    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
-
-    strcpy(host_header, host_string);
-
-    curl_headers =
-        curl_slist_append(curl_headers, strncat(host_header, parent_obj->domain->u.file.filepath_name,
-                                                host_header_len - strlen(host_string) - 1));
-
-    /* Disable use of Expect: 100 Continue HTTP response */
-    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP GET request: %s",
-                        curl_err_buf);
-
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-    printf("   /**********************************\\\n");
-    printf("-> | Making GET request to the server |\n");
-    printf("   \\**********************************/\n\n");
-#endif
-
-    CURL_PERFORM(curl, H5E_LINK, H5E_PATH, FAIL);
-
-    if (CURLE_OK != curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_response))
-        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get HTTP response code");
-
-    ret_value = HTTP_SUCCESS(http_response);
+    if (HTTP_SUCCESS(http_response))
+        ret_value = TRUE;
+    else
+        HANDLE_RESPONSE(http_response, H5E_ATTR, H5E_CANTGET, FAIL);
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Object %s\n\n", ret_value ? "found" : "not found");
 #endif
-
-    /* Clean up the cURL headers to prevent issues in potential recursive call */
-    curl_slist_free_all(curl_headers);
-    curl_headers = NULL;
 
     if (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 0)) {
 
@@ -2317,8 +2294,6 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
 done:
     if (tmp_link_val)
         RV_free(tmp_link_val);
-    if (host_header)
-        RV_free(host_header);
     if (url_encoded_path_name)
         RV_free(url_encoded_path_name);
     if (url_encoded_link_name)
@@ -2329,11 +2304,6 @@ done:
     if (external_file)
         if (RV_file_close(external_file, H5P_DEFAULT, NULL) < 0)
             FUNC_DONE_ERROR(H5E_LINK, H5E_CANTCLOSEOBJ, FAIL, "can't close file referenced by external link");
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
 
     return ret_value;
 } /* end RV_find_object_by_path */
@@ -2483,7 +2453,7 @@ RV_copy_object_loc_info_callback(char *HTTP_response, void *callback_data_in, vo
     /* If retrieved domain is different than the domain through which this object
      * was accessed, replace the returned object's domain. */
     if (is_external_domain) {
-        if (NULL == (new_domain = RV_malloc(sizeof(RV_object_t))))
+        if (NULL == (new_domain = RV_calloc(sizeof(RV_object_t))))
             FUNC_GOTO_ERROR(H5E_CALLBACK, H5E_CANTALLOC, FAIL, "failed to allocate memory for new domain");
 
         memcpy(new_domain, &found_domain, sizeof(RV_object_t));
@@ -2548,6 +2518,15 @@ done:
         RV_free(GCPL_buf);
         GCPL_buf                  = NULL;
         loc_info_out->GCPL_base64 = NULL;
+
+        if (new_domain) {
+            RV_free(new_domain->u.file.filepath_name);
+            RV_free(new_domain->u.file.server_info.username);
+            RV_free(new_domain->u.file.server_info.password);
+            RV_free(new_domain->u.file.server_info.base_URL);
+            RV_free(new_domain->handle_path);
+            RV_free(new_domain);
+        }
     }
 
     return ret_value;
@@ -3898,4 +3877,449 @@ RV_JSON_escape_string(const char *in, char *out, size_t *out_size)
 done:
 
     return ret_value;
+}
+
+/* Helper function to perform a DELETE request to an endpoint on a server.
+ * Request endpoint must contain a leading slash. */
+long
+RV_curl_delete(server_info_t *server_info, const char *request_endpoint, const char *filename)
+{
+    long   ret_value       = FAIL;
+    CURL  *curl_local      = NULL;
+    size_t host_header_len = 0;
+
+    char               curl_local_err_buf[CURL_ERROR_SIZE];
+    char              *host_header = NULL;
+    char               request_url[URL_MAX_LENGTH];
+    int                url_len            = 0;
+    struct curl_slist *curl_headers_local = NULL;
+
+    /* Initial curl handle setup */
+    if ((curl_local = RV_curl_setup_handle(server_info, curl_local_err_buf)) == NULL)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTCREATE, FAIL, "can't create curl handle");
+
+    /* Setup the host header */
+    host_header_len = strlen(filename) + strlen(host_string) + 1;
+
+    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
+
+    strcpy(host_header, host_string);
+
+    curl_headers_local = curl_slist_append(
+        curl_headers_local, strncat(host_header, filename, host_header_len - strlen(host_string) - 1));
+
+    /* Disable use of Expect: 100 Continue HTTP response */
+    curl_headers_local = curl_slist_append(curl_headers_local, "Expect:");
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_HTTPHEADER, curl_headers_local))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
+                        curl_local_err_buf);
+
+    /* Assemble request url */
+    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s%s", server_info->base_URL, request_endpoint)) <
+        0)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL, "snprintf error");
+
+    if (url_len >= URL_MAX_LENGTH)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL,
+                        "H5Adelete(_by_name) request URL exceeded maximum URL size");
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_URL, request_url))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
+                        curl_local_err_buf);
+
+    /* Make DELETE request */
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_CUSTOMREQUEST, "DELETE"))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP DELETE request: %s",
+                        curl_local_err_buf);
+#ifdef RV_CONNECTOR_DEBUG
+    printf("-> Deleting object at URL: %s\n\n", request_url);
+
+    printf("   /*************************************\\\n");
+    printf("-> | Making DELETE request to the server |\n");
+    printf("   \\*************************************/\n\n");
+#endif
+
+    CURL_PERFORM_NO_ERR(curl_local, FAIL);
+
+    if (CURLE_OK != curl_easy_getinfo(curl_local, CURLINFO_RESPONSE_CODE, &ret_value))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, ret_value, "can't get HTTP response code");
+
+done:
+    if (host_header)
+        RV_free(host_header);
+
+    if (curl_headers_local) {
+        curl_slist_free_all(curl_headers_local);
+        curl_headers_local = NULL;
+    }
+
+    if (curl_local) {
+        curl_easy_cleanup(curl_local);
+    }
+
+    return ret_value;
+}
+
+/* Helper function to perform a PUT request to an endpoint on a server.
+ * Request endpoint must contain a leading slash. */
+long
+RV_curl_put(server_info_t *server_info, const char *request_endpoint, const char *filename,
+            upload_info *uinfo, content_type_t content_type)
+{
+    long   ret_value       = FAIL;
+    CURL  *curl_local      = NULL;
+    size_t host_header_len = 0;
+
+    char               curl_local_err_buf[CURL_ERROR_SIZE];
+    char              *host_header = NULL;
+    char               request_url[URL_MAX_LENGTH];
+    int                url_len            = 0;
+    struct curl_slist *curl_headers_local = NULL;
+
+    if ((curl_local = RV_curl_setup_handle(server_info, curl_local_err_buf)) == NULL)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTCREATE, FAIL, "can't create curl handle");
+
+    /* Setup the host header */
+    host_header_len = strlen(filename) + strlen(host_string) + 1;
+    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
+
+    strcpy(host_header, host_string);
+
+    curl_headers_local = curl_slist_append(
+        curl_headers_local, strncat(host_header, filename, host_header_len - strlen(host_string) - 1));
+
+    /* Disable use of Expect: 100 Continue HTTP response */
+    curl_headers_local = curl_slist_append(curl_headers_local, "Expect:");
+
+    /* Specify type of content being sent through cURL */
+    switch (content_type) {
+        case CONTENT_TYPE_JSON:
+            curl_headers_local = curl_slist_append(curl_headers_local, "Content-Type: application/json");
+            break;
+        case CONTENT_TYPE_OCTET_STREAM:
+            curl_headers_local =
+                curl_slist_append(curl_headers_local, "Content-Type: application/octet-stream");
+            break;
+        case CONTENT_TYPE_UNINIT:
+            FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "content type of transfer is unspecified");
+            break;
+    }
+
+    /* Assemble request url */
+    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s%s", server_info->base_URL, request_endpoint)) <
+        0)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL, "snprintf error");
+
+    if (url_len >= URL_MAX_LENGTH)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL,
+                        "H5Adelete(_by_name) request URL exceeded maximum URL size");
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_HTTPHEADER, curl_headers_local))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
+                        curl_local_err_buf);
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_UPLOAD, 1))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP PUT request: %s",
+                        curl_local_err_buf);
+    if (uinfo) {
+        if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_READDATA, uinfo))
+            FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL PUT data: %s",
+                            curl_local_err_buf);
+        if (CURLE_OK !=
+            curl_easy_setopt(curl_local, CURLOPT_INFILESIZE_LARGE, (curl_off_t)uinfo->buffer_size))
+            FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL PUT data size: %s",
+                            curl_local_err_buf);
+    }
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_URL, request_url))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
+                        curl_local_err_buf);
+
+#ifdef RV_CONNECTOR_DEBUG
+    printf("   /**********************************\\\n");
+    printf("-> | Making PUT request to the server |\n");
+    printf("   \\**********************************/\n\n");
+#endif
+
+    CURL_PERFORM_NO_ERR(curl_local, FAIL);
+
+    if (CURLE_OK != curl_easy_getinfo(curl_local, CURLINFO_RESPONSE_CODE, &ret_value))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, ret_value, "can't get HTTP response code");
+done:
+
+    if (host_header)
+        RV_free(host_header);
+
+    if (curl_headers_local) {
+        curl_slist_free_all(curl_headers_local);
+        curl_headers_local = NULL;
+    }
+
+    if (curl_local)
+        curl_easy_cleanup(curl_local);
+
+    return ret_value;
+}
+
+/* Helper function to perform a GET request to an endpoint on a server.
+ * Request endpoint must contain a leading slash. */
+long
+RV_curl_get(server_info_t *server_info, const char *request_endpoint, const char *filename,
+            content_type_t content_type)
+{
+    herr_t ret_value       = FAIL;
+    CURL  *curl_local      = NULL;
+    size_t host_header_len = 0;
+
+    char               curl_local_err_buf[CURL_ERROR_SIZE];
+    char              *host_header = NULL;
+    char               request_url[URL_MAX_LENGTH];
+    int                url_len            = 0;
+    struct curl_slist *curl_headers_local = NULL;
+
+    if ((curl_local = RV_curl_setup_handle(server_info, curl_local_err_buf)) == NULL)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTCREATE, FAIL, "can't create curl handle");
+
+    /* Setup the host header */
+    host_header_len = strlen(filename) + strlen(host_string) + 1;
+    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
+
+    strcpy(host_header, host_string);
+
+    curl_headers_local = curl_slist_append(
+        curl_headers_local, strncat(host_header, filename, host_header_len - strlen(host_string) - 1));
+
+    /* Specify type of content being sent through cURL */
+    switch (content_type) {
+        case CONTENT_TYPE_JSON:
+            curl_headers_local = curl_slist_append(curl_headers_local, "Accept: application/json");
+            break;
+        case CONTENT_TYPE_OCTET_STREAM:
+            curl_headers_local = curl_slist_append(curl_headers_local, "Accept: application/octet-stream");
+            break;
+        case CONTENT_TYPE_UNINIT:
+            FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "content type of transfer is unspecified");
+            break;
+    }
+
+    /* Disable use of Expect: 100 Continue HTTP response */
+    curl_headers_local = curl_slist_append(curl_headers_local, "Expect:");
+
+    /* Assemble request url */
+    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s%s", server_info->base_URL, request_endpoint)) <
+        0)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL, "snprintf error");
+
+    if (url_len >= URL_MAX_LENGTH)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL, "cURL GET request URL exceeded maximum URL size");
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_HTTPHEADER, curl_headers_local))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
+                        curl_local_err_buf);
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_HTTPGET, 1))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP PUT request: %s",
+                        curl_local_err_buf);
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_URL, request_url))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
+                        curl_local_err_buf);
+
+#ifdef RV_CONNECTOR_DEBUG
+    printf("   /**********************************\\\n");
+    printf("-> | Making GET request to the server |\n");
+    printf("   \\**********************************/\n\n");
+#endif
+
+    CURL_PERFORM_NO_ERR(curl_local, FAIL);
+
+    if (CURLE_OK != curl_easy_getinfo(curl_local, CURLINFO_RESPONSE_CODE, &ret_value))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, FAIL, "can't get HTTP response code");
+
+done:
+    if (host_header)
+        RV_free(host_header);
+
+    if (curl_headers_local) {
+        curl_slist_free_all(curl_headers_local);
+        curl_headers_local = NULL;
+    }
+
+    if (curl_local)
+        curl_easy_cleanup(curl_local);
+
+    return ret_value;
+}
+
+/* Helper function to perform a POST request to an endpoint on a server.
+ * Request endpoint must contain a leading slash. */
+long
+RV_curl_post(server_info_t *server_info, const char *request_endpoint, const char *filename,
+             const char *post_data, size_t data_size, content_type_t content_type)
+{
+    herr_t ret_value       = FAIL;
+    CURL  *curl_local      = NULL;
+    size_t host_header_len = 0;
+
+    char               curl_local_err_buf[CURL_ERROR_SIZE];
+    char              *host_header = NULL;
+    char               request_url[URL_MAX_LENGTH];
+    int                url_len            = 0;
+    struct curl_slist *curl_headers_local = NULL;
+    curl_off_t         _data_size;
+
+    if ((curl_local = RV_curl_setup_handle(server_info, curl_local_err_buf)) == NULL)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTCREATE, FAIL, "can't create curl handle");
+
+    /* Setup the host header */
+    host_header_len = strlen(filename) + strlen(host_string) + 1;
+    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
+
+    strcpy(host_header, host_string);
+
+    curl_headers_local = curl_slist_append(
+        curl_headers_local, strncat(host_header, filename, host_header_len - strlen(host_string) - 1));
+
+    /* Specify type of content being sent through cURL */
+    switch (content_type) {
+        case CONTENT_TYPE_JSON:
+            curl_headers_local = curl_slist_append(curl_headers_local, "Accept: application/json");
+            break;
+        case CONTENT_TYPE_OCTET_STREAM:
+            curl_headers_local = curl_slist_append(curl_headers_local, "Accept: application/octet-stream");
+            break;
+        case CONTENT_TYPE_UNINIT:
+            FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "content type of transfer is unspecified");
+            break;
+    }
+
+    /* Disable use of Expect: 100 Continue HTTP response */
+    curl_headers_local = curl_slist_append(curl_headers_local, "Expect:");
+
+    /* Assemble request url */
+    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s%s", server_info->base_URL, request_endpoint)) <
+        0)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_BADVALUE, FAIL, "snprintf error");
+
+    if (url_len >= URL_MAX_LENGTH)
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_SYSERRSTR, FAIL, "cURL GET request URL exceeded maximum URL size");
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_HTTPHEADER, curl_headers_local))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
+                        curl_local_err_buf);
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_POST, 1))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP PUT request: %s",
+                        curl_local_err_buf);
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_POSTFIELDS, post_data))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL POST data: %s", curl_local_err_buf);
+
+    /* Make sure that the size of the create request HTTP body can safely be cast to a curl_off_t */
+    if (sizeof(curl_off_t) < sizeof(size_t))
+        ASSIGN_TO_SMALLER_SIZE(_data_size, curl_off_t, data_size, size_t)
+    else if (sizeof(curl_off_t) > sizeof(size_t))
+        _data_size = (curl_off_t)data_size;
+    else
+        ASSIGN_TO_SAME_SIZE_UNSIGNED_TO_SIGNED(_data_size, curl_off_t, data_size, size_t)
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_POSTFIELDSIZE_LARGE, _data_size))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL POST data size: %s",
+                        curl_local_err_buf);
+
+    if (CURLE_OK != curl_easy_setopt(curl_local, CURLOPT_URL, request_url))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
+                        curl_local_err_buf);
+
+#ifdef RV_CONNECTOR_DEBUG
+    printf("   /**********************************\\\n");
+    printf("-> | Making POST request to the server |\n");
+    printf("   \\**********************************/\n\n");
+#endif
+
+    CURL_PERFORM_NO_ERR(curl_local, FAIL);
+
+    if (CURLE_OK != curl_easy_getinfo(curl_local, CURLINFO_RESPONSE_CODE, &ret_value))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, ret_value, "can't get HTTP response code");
+
+done:
+    if (host_header)
+        RV_free(host_header);
+
+    if (curl_headers_local) {
+        curl_slist_free_all(curl_headers_local);
+        curl_headers_local = NULL;
+    }
+
+    if (curl_local)
+        curl_easy_cleanup(curl_local);
+
+    return ret_value;
+}
+
+/* Helper function that creates and sets some fields on a cURL handle. */
+CURL *
+RV_curl_setup_handle(server_info_t *server_info, char *err_buf)
+{
+    CURL                   *new_curl_handle = NULL;
+    curl_version_info_data *curl_ver        = NULL;
+    char                    user_agent[128] = {'\0'};
+    herr_t                  ret_value       = SUCCEED;
+
+    /* Initialize cURL */
+    if (!H5_rest_curl_initialized_g && (CURLE_OK != curl_global_init(CURL_GLOBAL_ALL)))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't initialize cURL");
+
+    H5_rest_curl_initialized_g = true;
+
+    if (NULL == (new_curl_handle = curl_easy_init()))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTINIT, FAIL, "can't initialize cURL easy handle");
+
+    /* Instruct cURL to use the buffer for error messages */
+    if (CURLE_OK != curl_easy_setopt(new_curl_handle, CURLOPT_ERRORBUFFER, err_buf))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set cURL error buffer");
+
+    /* Allocate buffer for cURL to write responses to */
+    /* TODO - For now this is still global. Have the local handles share the global buffer. */
+
+    /*
+    if (NULL == (response_buffer.buffer = (char *)RV_malloc(CURL_RESPONSE_BUFFER_DEFAULT_SIZE)))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTALLOC, FAIL, "can't allocate cURL response buffer");
+    response_buffer.buffer_size  = CURL_RESPONSE_BUFFER_DEFAULT_SIZE;
+    response_buffer.curr_buf_ptr = response_buffer.buffer;
+    */
+
+    /* Redirect cURL output to response buffer */
+    if (CURLE_OK !=
+        curl_easy_setopt(new_curl_handle, CURLOPT_WRITEFUNCTION, H5_rest_curl_write_data_callback))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set cURL write function: %s", err_buf);
+
+    /* Set cURL read function for UPLOAD operations */
+    if (CURLE_OK != curl_easy_setopt(new_curl_handle, CURLOPT_READFUNCTION, H5_rest_curl_read_data_callback))
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "can't set cURL read function: %s", err_buf);
+
+    /* Set user agent string */
+    curl_ver = curl_version_info(CURLVERSION_NOW);
+    if (snprintf(user_agent, sizeof(user_agent), "libhdf5/%d.%d.%d (%s; %s v%s)", H5_VERS_MAJOR,
+                 H5_VERS_MINOR, H5_VERS_RELEASE, curl_ver->host, HDF5_VOL_REST_LIB_NAME,
+                 HDF5_VOL_REST_LIB_VER) < 0) {
+        FUNC_GOTO_ERROR(H5E_VOL, H5E_SYSERRSTR, FAIL, "error creating user agent string");
+    }
+
+    if (CURLE_OK != curl_easy_setopt(new_curl_handle, CURLOPT_USERAGENT, user_agent))
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "error while setting CURL option (CURLOPT_USERAGENT)");
+
+    if (CURLE_OK != curl_easy_setopt(new_curl_handle, CURLOPT_USERNAME, server_info->username))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL username: %s", err_buf);
+    if (CURLE_OK != curl_easy_setopt(new_curl_handle, CURLOPT_PASSWORD, server_info->password))
+        FUNC_GOTO_ERROR(H5E_INTERNAL, H5E_CANTSET, FAIL, "can't set cURL password: %s", err_buf);
+
+done:
+    if (ret_value < 0) {
+        curl_easy_cleanup(new_curl_handle);
+        new_curl_handle = NULL;
+    }
+
+    return new_curl_handle;
 }

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -582,6 +582,12 @@ typedef struct dataset_read_info {
 
 typedef enum transfer_type_t { UNINIT = 0, READ = 1, WRITE = 2 } transfer_type_t;
 
+typedef enum content_type_t {
+    CONTENT_TYPE_UNINIT       = 0,
+    CONTENT_TYPE_JSON         = 1,
+    CONTENT_TYPE_OCTET_STREAM = 2
+} content_type_t;
+
 typedef struct dataset_transfer_info {
     struct curl_slist     *curl_headers;
     char                  *host_headers;
@@ -748,6 +754,15 @@ herr_t RV_curl_multi_perform(CURL *curl_multi_ptr, dataset_transfer_info *transf
                              herr_t(success_callback)(hid_t mem_type_id, hid_t mem_space_id,
                                                       hid_t file_type_id, hid_t file_space_id, void *buf,
                                                       struct response_buffer resp_buffer));
+
+/* Helper functions for cURL requests to the server */
+long RV_curl_delete(server_info_t *server_info, const char *request_endpoint, const char *filename);
+long RV_curl_put(server_info_t *server_info, const char *request_endpoint, const char *filename,
+                 upload_info *uinfo, content_type_t content_type);
+long RV_curl_get(server_info_t *server_info, const char *request_endpoint, const char *filename,
+                 content_type_t content_type);
+long RV_curl_post(server_info_t *server_info, const char *request_endpoint, const char *filename,
+                  const char *post_data, size_t post_size, content_type_t content_type);
 
 /* Dtermine if datatype conversion is necessary */
 htri_t RV_need_tconv(hid_t src_type_id, hid_t dst_type_id);

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -756,13 +756,14 @@ herr_t RV_curl_multi_perform(CURL *curl_multi_ptr, dataset_transfer_info *transf
                                                       struct response_buffer resp_buffer));
 
 /* Helper functions for cURL requests to the server */
-long RV_curl_delete(server_info_t *server_info, const char *request_endpoint, const char *filename);
-long RV_curl_put(server_info_t *server_info, const char *request_endpoint, const char *filename,
-                 upload_info *uinfo, content_type_t content_type);
-long RV_curl_get(server_info_t *server_info, const char *request_endpoint, const char *filename,
-                 content_type_t content_type);
-long RV_curl_post(server_info_t *server_info, const char *request_endpoint, const char *filename,
-                  const char *post_data, size_t post_size, content_type_t content_type);
+long RV_curl_delete(CURL *curl_handle, server_info_t *server_info, const char *request_endpoint,
+                    const char *filename);
+long RV_curl_put(CURL *curl_handle, server_info_t *server_info, const char *request_endpoint,
+                 const char *filename, upload_info *uinfo, content_type_t content_type);
+long RV_curl_get(CURL *curl_handle, server_info_t *server_info, const char *request_endpoint,
+                 const char *filename, content_type_t content_type);
+long RV_curl_post(CURL *curl_handle, server_info_t *server_info, const char *request_endpoint,
+                  const char *filename, const char *post_data, size_t post_size, content_type_t content_type);
 
 /* Dtermine if datatype conversion is necessary */
 htri_t RV_need_tconv(hid_t src_type_id, hid_t dst_type_id);

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -272,7 +272,7 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
     uinfo.buffer_size = (size_t)create_request_body_len;
     uinfo.bytes_sent  = 0;
 
-    http_response = RV_curl_put(&new_attribute->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_put(curl, &new_attribute->domain->u.file.server_info, request_endpoint,
                                 new_attribute->domain->u.file.filepath_name, &uinfo, CONTENT_TYPE_JSON);
     if (!HTTP_SUCCESS(http_response))
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTCREATE, NULL, "can't create attribute");
@@ -527,7 +527,7 @@ RV_attr_open(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_na
                 FUNC_GOTO_ERROR(H5E_ATTR, H5E_SYSERRSTR, NULL,
                                 "attribute open URL exceeded maximum URL size");
 
-            if (RV_curl_get(&attribute->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &attribute->domain->u.file.server_info, request_endpoint,
                             attribute->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, NULL, "can't get attribute");
 
@@ -579,7 +579,7 @@ RV_attr_open(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_na
     printf("-> URL for attribute open request: %s\n\n", request_endpoint);
 #endif
 
-    if (RV_curl_get(&attribute->domain->u.file.server_info, request_endpoint,
+    if (RV_curl_get(curl, &attribute->domain->u.file.server_info, request_endpoint,
                     attribute->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, NULL, "can't get attribute");
 
@@ -741,7 +741,7 @@ RV_attr_read(void *attr, hid_t dtype_id, void *buf, hid_t dxpl_id, void **req)
     printf("-> URL for attribute read request: %s\n\n", request_endpoint);
 #endif
 
-    if (RV_curl_get(&attribute->domain->u.file.server_info, request_endpoint,
+    if (RV_curl_get(curl, &attribute->domain->u.file.server_info, request_endpoint,
                     attribute->domain->u.file.filepath_name, content_type) < 0)
         FUNC_GOTO_ERROR(H5E_ATTR, H5E_READERROR, FAIL, "can't read from attribute");
 
@@ -873,7 +873,7 @@ RV_attr_write(void *attr, hid_t dtype_id, const void *buf, hid_t dxpl_id, void *
     /* Clear response buffer */
     memset(response_buffer.buffer, 0, response_buffer.buffer_size);
 
-    http_response = RV_curl_put(&attribute->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_put(curl, &attribute->domain->u.file.server_info, request_endpoint,
                                 attribute->domain->u.file.filepath_name, &uinfo,
                                 (is_transfer_binary ? CONTENT_TYPE_OCTET_STREAM : CONTENT_TYPE_JSON));
 
@@ -1094,7 +1094,7 @@ RV_attr_get(void *obj, H5VL_attr_get_args_t *args, hid_t dxpl_id, void **req)
                         FUNC_GOTO_ERROR(H5E_ATTR, H5E_SYSERRSTR, FAIL,
                                         "attribute open URL exceeded maximum URL size");
 
-                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                    if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                     loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get attribute");
 
@@ -1124,7 +1124,7 @@ RV_attr_get(void *obj, H5VL_attr_get_args_t *args, hid_t dxpl_id, void **req)
             } /* end switch */
 
             /* Make a GET request to the server to retrieve the attribute's info */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get attribute");
 
@@ -1225,7 +1225,7 @@ RV_attr_get(void *obj, H5VL_attr_get_args_t *args, hid_t dxpl_id, void **req)
                         FUNC_GOTO_ERROR(H5E_ATTR, H5E_SYSERRSTR, FAIL,
                                         "attribute open URL exceeded maximum URL size");
 
-                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                    if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                     loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                         FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get attribute");
 
@@ -1407,7 +1407,7 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
                                 "H5Adelete(_by_name) request URL exceeded maximum URL size");
 
             http_response =
-                RV_curl_delete(&loc_obj->domain->u.file.server_info, (const char *)request_endpoint,
+                RV_curl_delete(curl, &loc_obj->domain->u.file.server_info, (const char *)request_endpoint,
                                (const char *)loc_obj->domain->u.file.filepath_name);
 
             if (!HTTP_SUCCESS(http_response))
@@ -1513,7 +1513,7 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
                                 "H5Adelete(_by_name) request URL exceeded maximum URL size");
 
             http_response =
-                RV_curl_delete(&loc_obj->domain->u.file.server_info, (const char *)request_endpoint,
+                RV_curl_delete(curl, &loc_obj->domain->u.file.server_info, (const char *)request_endpoint,
                                (const char *)loc_obj->domain->u.file.filepath_name);
 
             if (!HTTP_SUCCESS(http_response))
@@ -1606,7 +1606,7 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
                 FUNC_GOTO_ERROR(H5E_ATTR, H5E_SYSERRSTR, FAIL,
                                 "H5Aexists(_by_name) request URL exceeded maximum URL size");
 
-            http_response = RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            http_response = RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                         loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
 
             if (HTTP_SUCCESS(http_response))
@@ -1970,7 +1970,7 @@ RV_attr_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_attr_speci
 
             /* Make a GET request to the server to retrieve all of the attributes attached to the given object
              */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get attribute");
 

--- a/src/rest_vol_config.h.in
+++ b/src/rest_vol_config.h.in
@@ -126,13 +126,13 @@
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD
-#if defined __BIG_ENDIAN__
-#define WORDS_BIGENDIAN 1
-#endif
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
 #else
-#ifndef WORDS_BIGENDIAN
-#undef WORDS_BIGENDIAN
-#endif
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
 #endif
 
 /* Define to empty if `const' does not conform to ANSI C. */

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -221,7 +221,7 @@ RV_dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const char *na
     printf("-> Dataset creation request URL: %s\n\n", request_url);
 #endif
 
-    http_response = RV_curl_post(&new_dataset->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_post(curl, &new_dataset->domain->u.file.server_info, request_endpoint,
                                  new_dataset->domain->u.file.filepath_name, (const char *)create_request_body,
                                  create_request_body_len, CONTENT_TYPE_JSON);
 
@@ -1332,7 +1332,7 @@ RV_dataset_get(void *obj, H5VL_dataset_get_args_t *args, hid_t dxpl_id, void **r
             /* Make GET request to dataset with 'verbose' parameter for HSDS. */
             snprintf(request_endpoint, URL_MAX_LENGTH, "%s%s%s", "/datasets/", dset->URI, "?verbose=1");
 
-            if (RV_curl_get(&dset->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &dset->domain->u.file.server_info, request_endpoint,
                             dset->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get dataset");
 

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -238,7 +238,7 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     printf("-> Datatype commit URL: %s\n\n", request_endpoint);
 #endif
 
-    http_response = RV_curl_post(&parent->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_post(curl, &parent->domain->u.file.server_info, request_endpoint,
                                  parent->domain->u.file.filepath_name, (const char *)commit_request_body,
                                  (size_t)commit_request_len, CONTENT_TYPE_JSON);
 

--- a/src/rest_vol_file.c
+++ b/src/rest_vol_file.c
@@ -50,17 +50,17 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
 {
     RV_object_t *new_file = NULL;
     size_t       name_length;
-    size_t       host_header_len         = 0;
     size_t       base64_buf_size         = 0;
     size_t       plist_nalloc            = 0;
     size_t       create_request_nalloc   = 0;
     int          create_request_body_len = 0;
-    char        *host_header             = NULL;
     char        *base64_plist_buffer     = NULL;
     const char  *fmt_string              = NULL;
     char        *create_request_body     = NULL;
     void        *ret_value               = NULL;
     void        *binary_plist_buffer     = NULL;
+    const char  *request_endpoint        = NULL;
+    long         http_response;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received file create call with following parameters:\n");
@@ -131,76 +131,23 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     strncpy(new_file->u.file.filepath_name, name, name_length);
     new_file->u.file.filepath_name[name_length] = '\0';
 
-    /* Setup the host header */
-    host_header_len = name_length + strlen(host_string) + 1;
-    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for request Host header");
-
-    strcpy(host_header, host_string);
-
-    curl_headers = curl_slist_append(curl_headers, strncat(host_header, name, name_length));
-
-    /* Disable use of Expect: 100 Continue HTTP response */
-    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, new_file->u.file.server_info.username))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL username: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, new_file->u.file.server_info.password))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, new_file->u.file.server_info.base_URL))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
-
     /* Before making the actual request, check the file creation flags for
      * the use of H5F_ACC_TRUNC. In this case, we want to check with the
      * server before trying to create a file which already exists.
      */
     if (flags & H5F_ACC_TRUNC) {
-        long http_response;
 
-        if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set up cURL to make HTTP GET request: %s",
-                            curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-        printf("-> H5F_ACC_TRUNC specified; checking if file exists\n\n");
-
-        printf("   /**********************************\\\n");
-        printf("-> | Making GET request to the server |\n");
-        printf("   \\**********************************/\n\n");
-#endif
-
-        /* Note that we use the special version of CURL_PERFORM because if
-         * the file doesn't exist, and the check for this throws a 404 response,
-         * the standard CURL_PERFORM would fail this entire function. We don't
-         * want this, we just want to get an idea of whether the file exists
-         * or not.
-         */
-        CURL_PERFORM_NO_ERR(curl, NULL);
-
-        if (CURLE_OK != curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_response))
-            FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTGET, NULL, "can't get HTTP response code");
+        /* Don't fail function if this file doesn't exist */
+        http_response = RV_curl_get(&new_file->u.file.server_info, "/", new_file->u.file.filepath_name,
+                                    CONTENT_TYPE_JSON);
 
         /* If the file exists, go ahead and delete it before proceeding */
         if (HTTP_SUCCESS(http_response)) {
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE"))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL,
-                                "can't set up cURL to make HTTP DELETE request: %s", curl_err_buf);
+            http_response = RV_curl_delete(&new_file->u.file.server_info, "/",
+                                           (const char *)new_file->u.file.filepath_name);
 
-#ifdef RV_CONNECTOR_DEBUG
-            printf("-> File existed and H5F_ACC_TRUNC specified; deleting file\n\n");
-
-            printf("   /*************************************\\\n");
-            printf("-> | Making DELETE request to the server |\n");
-            printf("   \\*************************************/\n\n");
-#endif
-
-            CURL_PERFORM(curl, H5E_FILE, H5E_CANTREMOVE, NULL);
-
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, NULL))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't reset cURL custom request: %s",
-                                curl_err_buf);
+            if (!HTTP_SUCCESS(http_response))
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTREMOVE, NULL, "can't delete existing file");
         } /* end if */
     }     /* end if */
 
@@ -240,22 +187,11 @@ RV_file_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, h
     uinfo.buffer_size = (size_t)create_request_body_len;
     uinfo.bytes_sent  = 0;
 
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_UPLOAD, 1))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set up cURL to make HTTP PUT request: %s",
-                        curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_READDATA, &uinfo))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL PUT data: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)create_request_body_len))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL PUT data size: %s", curl_err_buf);
+    http_response = RV_curl_put(&new_file->u.file.server_info, "/", new_file->u.file.filepath_name, &uinfo,
+                                CONTENT_TYPE_JSON);
 
-#ifdef RV_CONNECTOR_DEBUG
-    printf("-> Creating file\n\n");
-
-    printf("   /**********************************\\\n");
-    printf("-> | Making PUT request to the server |\n");
-    printf("   \\**********************************/\n\n");
-#endif
-    CURL_PERFORM(curl, H5E_FILE, H5E_CANTCREATE, NULL);
+    if (!HTTP_SUCCESS(http_response))
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTCREATE, NULL, "can't create file");
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Created file\n\n");
@@ -288,9 +224,6 @@ done:
     } /* end if */
 #endif
 
-    if (host_header)
-        RV_free(host_header);
-
     RV_free(base64_plist_buffer);
     RV_free(binary_plist_buffer);
     RV_free(create_request_body);
@@ -299,19 +232,6 @@ done:
     if (new_file && !ret_value)
         if (RV_file_close(new_file, FAIL, NULL) < 0)
             FUNC_DONE_ERROR(H5E_FILE, H5E_CANTCLOSEOBJ, NULL, "can't close file");
-
-    /* Reset cURL custom request to prevent issues with future requests */
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, NULL))
-        FUNC_DONE_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't reset cURL custom request: %s", curl_err_buf);
-
-    /* Unset cURL UPLOAD option to ensure that future requests don't try to use PUT calls */
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_UPLOAD, 0))
-        FUNC_DONE_ERROR(H5E_ATTR, H5E_CANTSET, NULL, "can't unset cURL PUT option: %s", curl_err_buf);
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
 
     PRINT_ERROR_STACK;
 
@@ -336,9 +256,8 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
 {
     RV_object_t *file = NULL;
     size_t       name_length;
-    size_t       host_header_len = 0;
-    char        *host_header     = NULL;
-    void        *ret_value       = NULL;
+    void        *ret_value = NULL;
+    long         http_response;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received file open call with following parameters:\n");
@@ -384,39 +303,11 @@ RV_file_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, voi
     strncpy(file->u.file.filepath_name, name, name_length);
     file->u.file.filepath_name[name_length] = '\0';
 
-    /* Setup the host header */
-    host_header_len = name_length + strlen(host_string) + 1;
-    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't allocate space for request Host header");
+    http_response =
+        RV_curl_get(&file->u.file.server_info, "/", file->u.file.filepath_name, CONTENT_TYPE_JSON);
 
-    strcpy(host_header, host_string);
-
-    curl_headers = curl_slist_append(curl_headers, strncat(host_header, name, name_length));
-
-    /* Disable use of Expect: 100 Continue HTTP response */
-    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, file->u.file.server_info.username))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL username: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, file->u.file.server_info.password))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, file->u.file.server_info.base_URL))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set up cURL to make HTTP GET request: %s",
-                        curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-    printf("-> Retrieving info for file open\n\n");
-
-    printf("   /**********************************\\\n");
-    printf("-> | Making GET request to the server |\n");
-    printf("   \\**********************************/\n\n");
-#endif
-
-    CURL_PERFORM(curl, H5E_FILE, H5E_CANTOPENFILE, NULL);
+    if (!HTTP_SUCCESS(http_response))
+        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "can't get file");
 
     /* Store the opened file's URI */
     if (RV_parse_response(response_buffer.buffer, NULL, file->URI, RV_copy_object_URI_callback) < 0)
@@ -459,18 +350,10 @@ done:
     }
 #endif
 
-    if (host_header)
-        RV_free(host_header);
-
     /* Clean up allocated file object if there was an issue */
     if (file && !ret_value)
         if (RV_file_close(file, FAIL, NULL) < 0)
             FUNC_DONE_ERROR(H5E_FILE, H5E_CANTCLOSEOBJ, NULL, "can't close file");
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
 
     PRINT_ERROR_STACK;
 
@@ -672,12 +555,10 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
 {
     RV_object_t   *file      = (RV_object_t *)obj;
     herr_t         ret_value = SUCCEED;
-    size_t         host_header_len;
     size_t         name_length;
     long           http_response;
-    char          *host_header = NULL;
-    const char    *filename    = NULL;
-    char          *request_url = NULL;
+    const char    *filename = NULL;
+    char           request_endpoint[URL_MAX_LENGTH];
     server_info_t *server_info = NULL;
 
 #ifdef RV_CONNECTOR_DEBUG
@@ -704,50 +585,14 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
 
             name_length = strlen(filename);
 
-            /* Setup the host header */
-            host_header_len = name_length + strlen(host_string) + 1;
-
-            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL,
-                                "can't allocate space for request Host header");
-
-            strcpy(host_header, host_string);
-
-            curl_headers = curl_slist_append(curl_headers, strncat(host_header, filename, name_length));
-
-            /* Disable use of Expect: 100 Continue HTTP response */
-            curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-            if (NULL == (request_url = (char *)RV_malloc(
-                             strlen(flush_string) + strlen(target_domain->u.file.server_info.base_URL) + 1)))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate space for request URL");
-
-            snprintf(request_url, URL_MAX_LENGTH, "%s%s", target_domain->u.file.server_info.base_URL,
-                     flush_string);
-
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, file->u.file.server_info.username))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, file->u.file.server_info.password))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
+            snprintf(request_endpoint, URL_MAX_LENGTH, "%s", flush_string);
             /* Server only checks for flush parameter on PUT operations */
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL to make HTTP PUTrequest: %s",
-                                curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)0))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL upload size: %s", curl_err_buf);
 
-            CURL_PERFORM_NO_ERR(curl, FAIL);
-
-            if (CURLE_OK != curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_response))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get HTTP response code from cURL: %s",
-                                curl_err_buf);
-
-            if (http_response != HTTP_NO_CONTENT)
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTFLUSH, FAIL, "invalid server response from flush");
+            if (HTTP_NO_CONTENT !=
+                (http_response = RV_curl_put(&file->u.file.server_info, request_endpoint,
+                                             file->u.file.filepath_name, NULL, CONTENT_TYPE_JSON)))
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTFLUSH, FAIL, "unexpected return from flush: HTTP %zu",
+                                http_response);
 
             break;
         }
@@ -795,20 +640,6 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
 
             name_length = strlen(filename);
 
-            /* Setup the host header */
-            host_header_len = name_length + strlen(host_string) + 1;
-
-            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL,
-                                "can't allocate space for request Host header");
-
-            strcpy(host_header, host_string);
-
-            curl_headers = curl_slist_append(curl_headers, strncat(host_header, filename, name_length));
-
-            /* Disable use of Expect: 100 Continue HTTP response */
-            curl_headers = curl_slist_append(curl_headers, "Expect:");
-
             /* H5Fdelete doesn't receive a file handle, so the username/password must be pulled
              * from environment for now */
             if ((server_info = RV_calloc(sizeof(server_info_t))) == NULL)
@@ -817,21 +648,10 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
             if (H5_rest_set_connection_information(server_info) < 0)
                 FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't get server connection information");
 
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, server_info->username))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, server_info->password))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
+            http_response = RV_curl_delete(server_info, "/", filename);
 
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, server_info->base_URL))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
-
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE"))
-                FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL,
-                                "can't set up cURL to make HTTP DELETE request: %s", curl_err_buf);
-
-            CURL_PERFORM(curl, H5E_FILE, H5E_CLOSEERROR, FAIL);
+            if (!HTTP_SUCCESS(http_response))
+                FUNC_GOTO_ERROR(H5E_FILE, H5E_CLOSEERROR, FAIL, "can't delete file");
 
             break;
         } /* H5VL_FILE_DELETE */
@@ -846,23 +666,6 @@ RV_file_specific(void *obj, H5VL_file_specific_args_t *args, hid_t dxpl_id, void
 
 done:
     PRINT_ERROR_STACK;
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
-
-    /* Restore CUSTOMREQUEST to internal default */
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, NULL))
-        FUNC_GOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP DELETE request: %s",
-                        curl_err_buf);
-
-    if (host_header) {
-        RV_free(host_header);
-    }
-
-    if (request_url)
-        RV_free(request_url);
 
     if (server_info) {
         RV_free(server_info->base_URL);

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -253,7 +253,7 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     printf("-> Group create request URL: %s\n\n", request_endpoint);
 #endif
 
-    http_response = RV_curl_post(&new_group->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_post(curl, &new_group->domain->u.file.server_info, request_endpoint,
                                  parent->domain->u.file.filepath_name,
                                  create_request_body ? (const char *)create_request_body : "",
                                  (size_t)create_request_body_len, CONTENT_TYPE_JSON);
@@ -584,7 +584,7 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
                     FUNC_GOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL, "invalid loc_params type");
             } /* end switch */
 
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't get group");
 

--- a/src/rest_vol_group.c
+++ b/src/rest_vol_group.c
@@ -44,23 +44,21 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
     RV_object_t *parent                = (RV_object_t *)obj;
     RV_object_t *new_group             = NULL;
     size_t       create_request_nalloc = 0;
-    size_t       host_header_len       = 0;
     size_t       base64_buf_size       = 0;
     size_t       plist_nalloc          = 0;
     size_t       path_size             = 0;
     size_t       path_len              = 0;
-    const char  *base_URL              = NULL;
-    char        *host_header           = NULL;
     char        *create_request_body   = NULL;
     char        *path_dirname          = NULL;
     char        *base64_plist_buffer   = NULL;
     char         target_URI[URI_MAX_LENGTH];
-    char         request_url[URL_MAX_LENGTH];
+    char         request_endpoint[URL_MAX_LENGTH];
     char        *escaped_group_name      = NULL;
     int          create_request_body_len = 0;
     int          url_len                 = 0;
     void        *binary_plist_buffer     = NULL;
     void        *ret_value               = NULL;
+    long         http_response;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received group create call with following parameters:\n");
@@ -76,9 +74,6 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 
     if (H5I_FILE != parent->obj_type && H5I_GROUP != parent->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object not a file or group");
-
-    if ((base_URL = parent->domain->u.file.server_info.base_URL) == NULL)
-        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "parent object does not have valid server URL");
 
     if (gapl_id == H5I_INVALID_HID)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid GAPL");
@@ -165,6 +160,7 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
                 if (H5Pget_create_intermediate_group(lcpl_id, &crt_intmd_group))
                     FUNC_GOTO_ERROR(H5E_PLIST, H5E_CANTGET, NULL, "can't get flag value in lcpl");
 
+                /* If group in provided path doesn't exist, create it */
                 if (crt_intmd_group) {
                     /* Remove trailing slash to avoid infinite loop due to H5_dirname */
                     if (path_dirname[strlen(path_dirname) - 1] == '/')
@@ -179,7 +175,12 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
                     search_ret = RV_find_object_by_path(parent, path_dirname, &obj_type,
                                                         RV_copy_object_URI_callback, NULL, target_URI);
 
-                    RV_group_close(intmd_group, H5P_DEFAULT, NULL);
+                    if (!search_ret || search_ret < 0)
+                        FUNC_GOTO_ERROR(H5E_SYM, H5E_PATH, NULL, "couldn't get URI of intermediate group");
+
+                    if (RV_group_close(intmd_group, H5P_DEFAULT, NULL) < 0)
+                        FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, NULL,
+                                        "can't close intermediate group");
                 }
                 else
                     FUNC_GOTO_ERROR(H5E_SYM, H5E_PATH, NULL, "can't locate target for group link");
@@ -241,59 +242,25 @@ RV_group_create(void *obj, const H5VL_loc_params_t *loc_params, const char *name
 #endif
     } /* end if */
 
-    /* Setup the host header */
-    host_header_len = strlen(parent->domain->u.file.filepath_name) + strlen(host_string) + 1;
-    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, NULL, "can't allocate space for request Host header");
-
-    strcpy(host_header, host_string);
-
-    curl_headers = curl_slist_append(curl_headers, strncat(host_header, parent->domain->u.file.filepath_name,
-                                                           host_header_len - strlen(host_string) - 1));
-
-    /* Disable use of Expect: 100 Continue HTTP response */
-    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-    /* Instruct cURL that we are sending JSON */
-    curl_headers = curl_slist_append(curl_headers, "Content-Type: application/json");
-
     /* Redirect cURL from the base URL to "/groups" to create the group */
-    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups", base_URL)) < 0)
+    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/groups")) < 0)
         FUNC_GOTO_ERROR(H5E_SYM, H5E_SYSERRSTR, NULL, "snprintf error");
 
     if (url_len >= URL_MAX_LENGTH)
         FUNC_GOTO_ERROR(H5E_SYM, H5E_SYSERRSTR, NULL, "group create URL size exceeded maximum URL size");
 
 #ifdef RV_CONNECTOR_DEBUG
-    printf("-> Group create request URL: %s\n\n", request_url);
+    printf("-> Group create request URL: %s\n\n", request_endpoint);
 #endif
 
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME, new_group->domain->u.file.server_info.username))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL username: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD, new_group->domain->u.file.server_info.password))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL password: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL HTTP headers: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_POST, 1))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set up cURL to make HTTP POST request: %s",
-                        curl_err_buf);
-    if (CURLE_OK !=
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, create_request_body ? create_request_body : ""))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL POST data: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)create_request_body_len))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL POST data size: %s", curl_err_buf);
-    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, NULL, "can't set cURL request URL: %s", curl_err_buf);
+    http_response = RV_curl_post(&new_group->domain->u.file.server_info, request_endpoint,
+                                 parent->domain->u.file.filepath_name,
+                                 create_request_body ? (const char *)create_request_body : "",
+                                 (size_t)create_request_body_len, CONTENT_TYPE_JSON);
 
-#ifdef RV_CONNECTOR_DEBUG
-    printf("-> Creating group\n\n");
-
-    printf("   /***********************************\\\n");
-    printf("-> | Making POST request to the server |\n");
-    printf("   \\***********************************/\n\n");
-#endif
-
-    CURL_PERFORM(curl, H5E_SYM, H5E_CANTCREATE, NULL);
+    if (!HTTP_SUCCESS(http_response))
+        FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTCREATE, NULL, "can't create group: received HTTP %ld",
+                        http_response);
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Created group\n\n");
@@ -325,8 +292,6 @@ done:
         RV_free(path_dirname);
     if (create_request_body)
         RV_free(create_request_body);
-    if (host_header)
-        RV_free(host_header);
 
     /* Clean up allocated group object if there was an issue */
     if (new_group && !ret_value)
@@ -337,11 +302,6 @@ done:
         RV_free(base64_plist_buffer);
     if (binary_plist_buffer)
         RV_free(binary_plist_buffer);
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
 
     if (escaped_group_name)
         RV_free(escaped_group_name);
@@ -507,12 +467,9 @@ done:
 herr_t
 RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
 {
-    RV_object_t *loc_obj         = (RV_object_t *)obj;
-    size_t       host_header_len = 0;
-    char        *host_header     = NULL;
-    char         request_url[URL_MAX_LENGTH];
+    RV_object_t *loc_obj = (RV_object_t *)obj;
+    char         request_endpoint[URL_MAX_LENGTH];
     int          url_len   = 0;
-    const char  *base_URL  = NULL;
     herr_t       ret_value = SUCCEED;
 
     loc_info loc_info_out;
@@ -525,8 +482,6 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
 
     if (H5I_FILE != loc_obj->obj_type && H5I_GROUP != loc_obj->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a group");
-    if ((base_URL = loc_obj->domain->u.file.server_info.base_URL) == NULL)
-        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parent object does not have valid server URL");
 
     switch (args->op_type) {
         /* H5Gget_create_plist */
@@ -554,8 +509,8 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
 #endif
 
                     /* Redirect cURL from the base URL to "/groups/<id>" to get information about the group */
-                    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s", base_URL,
-                                            loc_obj->URI)) < 0)
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/groups/%s", loc_obj->URI)) <
+                        0)
                         FUNC_GOTO_ERROR(H5E_SYM, H5E_SYSERRSTR, FAIL, "snprintf error");
 
                     if (url_len >= URL_MAX_LENGTH)
@@ -603,8 +558,7 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
 #endif
 
                     /* Redirect cURL from the base URL to "/groups/<id>" to get information about the group */
-                    if ((url_len =
-                             snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s", base_URL, temp_URI)) < 0)
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/groups/%s", temp_URI)) < 0)
                         FUNC_GOTO_ERROR(H5E_SYM, H5E_SYSERRSTR, FAIL, "snprintf error");
 
                     if (url_len >= URL_MAX_LENGTH)
@@ -630,44 +584,9 @@ RV_group_get(void *obj, H5VL_group_get_args_t *args, hid_t dxpl_id, void **req)
                     FUNC_GOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL, "invalid loc_params type");
             } /* end switch */
 
-            /* Setup the host header */
-            host_header_len = strlen(loc_obj->domain->u.file.filepath_name) + strlen(host_string) + 1;
-            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTALLOC, FAIL, "can't allocate space for request Host header");
-
-            strcpy(host_header, host_string);
-
-            curl_headers =
-                curl_slist_append(curl_headers, strncat(host_header, loc_obj->domain->u.file.filepath_name,
-                                                        host_header_len - strlen(host_string) - 1));
-
-            /* Disable use of Expect: 100 Continue HTTP response */
-            curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP GET request: %s",
-                                curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-            printf("-> Retrieving group info at URL: %s\n\n", request_url);
-
-            printf("   /**********************************\\\n");
-            printf("-> | Making GET request to the server |\n");
-            printf("   \\**********************************/\n\n");
-#endif
-
-            /* Make request to server to retrieve the group info */
-            CURL_PERFORM(curl, H5E_SYM, H5E_CANTGET, FAIL);
+            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                            loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
+                FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't get group");
 
             /* Parse response from server and retrieve the relevant group information
              * (currently, just the number of links in the group)
@@ -692,14 +611,6 @@ done:
         RV_free(loc_info_out.GCPL_base64);
         loc_info_out.GCPL_base64 = NULL;
     }
-
-    if (host_header)
-        RV_free(host_header);
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
 
     PRINT_ERROR_STACK;
 

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -323,7 +323,7 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
     uinfo.bytes_sent  = 0;
 
     // TODO - Check this uses right filename for external links
-    http_response = RV_curl_put(&new_link_loc_obj->domain->u.file.server_info, request_endpoint,
+    http_response = RV_curl_put(curl, &new_link_loc_obj->domain->u.file.server_info, request_endpoint,
                                 new_link_loc_obj->domain->u.file.filepath_name, &uinfo, CONTENT_TYPE_JSON);
 
     if (!HTTP_SUCCESS(http_response))
@@ -507,7 +507,7 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
             } /* end switch */
 
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
@@ -568,7 +568,7 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
                                 "H5Lget_name_by_idx request URL size exceeded maximum URL size");
 
             /* Make a GET request to the server to retrieve all of the links in the given group */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
@@ -653,7 +653,7 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
             } /* end switch */
 
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
@@ -783,7 +783,7 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                     FUNC_GOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "invalid loc_params type");
             } /* end switch */
 
-            http_response = RV_curl_delete(&loc_obj->domain->u.file.server_info, request_endpoint,
+            http_response = RV_curl_delete(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                            (const char *)loc_obj->domain->u.file.filepath_name);
 
             if (!HTTP_SUCCESS(http_response))
@@ -831,7 +831,7 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                 "H5Lexists request URL size exceeded maximum URL size");
 
-            http_response = RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            http_response = RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                         loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
             *ret          = HTTP_SUCCESS(http_response);
 
@@ -942,7 +942,7 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
             link_iter_data.iter_obj_id = link_iter_group_id;
 
             /* Make a GET request to the server to retrieve all of the links in the given group */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
@@ -1720,7 +1720,7 @@ RV_build_link_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func)(
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "link GET request URL size exceeded maximum URL size");
 
-                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                    if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                     loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -265,14 +265,12 @@ herr_t
 RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_args_t *args, hid_t dxpl_id,
               void **req)
 {
-    RV_object_t *loc_obj         = (RV_object_t *)obj;
-    size_t       host_header_len = 0;
-    char        *host_header     = NULL;
-    char         request_url[URL_MAX_LENGTH];
-    char        *found_object_name = NULL;
-    const char  *base_URL          = NULL;
-    int          url_len           = 0;
-    herr_t       ret_value         = SUCCEED;
+    RV_object_t *loc_obj = (RV_object_t *)obj;
+    char         request_endpoint[URL_MAX_LENGTH];
+    char        *found_object_name      = NULL;
+    const char  *parent_obj_type_header = NULL;
+    int          url_len                = 0;
+    herr_t       ret_value              = SUCCEED;
     loc_info     loc_info_out;
 
     loc_info_out.GCPL_base64 = NULL;
@@ -290,9 +288,6 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     if (H5I_FILE != loc_obj->obj_type && H5I_GROUP != loc_obj->obj_type &&
         H5I_DATATYPE != loc_obj->obj_type && H5I_DATASET != loc_obj->obj_type)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file, group, dataset or committed datatype");
-
-    if ((base_URL = loc_obj->domain->u.file.server_info.base_URL) == NULL)
-        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "location object does not have valid server URL");
 
     switch (args->op_type) {
         case H5VL_OBJECT_GET_NAME: {
@@ -344,60 +339,17 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                      * depending on the type of the object. Also set the
                      * object's type in the H5O_info2_t struct.
                      */
-                    switch (obj_type) {
-                        case H5I_FILE:
-                        case H5I_GROUP: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s", base_URL,
-                                                    loc_obj->URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
+                    if (RV_set_object_type_header(obj_type, &parent_obj_type_header) < 0)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL,
+                                        "target object not a group, datatype or dataset");
 
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                                "H5Oget_info request URL size exceeded maximum URL size");
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s",
+                                            parent_obj_type_header, loc_obj->URI)) < 0)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
 
-                            break;
-                        } /* H5I_FILE H5I_GROUP */
-
-                        case H5I_DATATYPE: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datatypes/%s", base_URL,
-                                                    loc_obj->URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
-
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                                "H5Oget_info request URL size exceeded maximum URL size");
-
-                            break;
-                        } /* H5I_DATATYPE */
-
-                        case H5I_DATASET: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datasets/%s", base_URL,
-                                                    loc_obj->URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
-
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                                "H5Oget_info request URL size exceeded maximum URL size");
-
-                            break;
-                        } /* H5I_DATASET */
-
-                        case H5I_ATTR:
-                        case H5I_UNINIT:
-                        case H5I_BADID:
-                        case H5I_DATASPACE:
-                        case H5I_VFL:
-                        case H5I_VOL:
-                        case H5I_GENPROP_CLS:
-                        case H5I_GENPROP_LST:
-                        case H5I_ERROR_CLASS:
-                        case H5I_ERROR_MSG:
-                        case H5I_ERROR_STACK:
-                        case H5I_NTYPES:
-                        default:
-                            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL,
-                                            "loc_id object is not a group, datatype or dataset");
-                    } /* end switch */
+                    if (url_len >= URL_MAX_LENGTH)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL,
+                                        "H5Oget_info request URL size exceeded maximum URL size");
 
 #ifdef RV_CONNECTOR_DEBUG
                     printf("-> H5Oget_info(): Object type: %s\n\n", object_type_to_string(obj_type));
@@ -443,63 +395,17 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                      * depending on the type of the object. Also set the
                      * object's type in the H5O_info2_t struct.
                      */
-                    switch (obj_type) {
-                        case H5I_FILE:
-                        case H5I_GROUP: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s", base_URL,
-                                                    temp_URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
+                    if (RV_set_object_type_header(obj_type, &parent_obj_type_header) < 0)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL,
+                                        "target object not a group, datatype or dataset");
 
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(
-                                    H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                    "H5Oget_info_by_name request URL size exceeded maximum URL size");
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s",
+                                            parent_obj_type_header, temp_URI)) < 0)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
 
-                            break;
-                        } /* H5I_FILE H5I_GROUP */
-
-                        case H5I_DATATYPE: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datatypes/%s", base_URL,
-                                                    temp_URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
-
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(
-                                    H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                    "H5Oget_info_by_name request URL size exceeded maximum URL size");
-
-                            break;
-                        } /* H5I_DATATYPE */
-
-                        case H5I_DATASET: {
-                            if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datasets/%s", base_URL,
-                                                    temp_URI)) < 0)
-                                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
-
-                            if (url_len >= URL_MAX_LENGTH)
-                                FUNC_GOTO_ERROR(
-                                    H5E_OBJECT, H5E_SYSERRSTR, FAIL,
-                                    "H5Oget_info_by_name request URL size exceeded maximum URL size");
-
-                            break;
-                        } /* H5I_DATASET */
-
-                        case H5I_ATTR:
-                        case H5I_UNINIT:
-                        case H5I_BADID:
-                        case H5I_DATASPACE:
-                        case H5I_VFL:
-                        case H5I_VOL:
-                        case H5I_GENPROP_CLS:
-                        case H5I_GENPROP_LST:
-                        case H5I_ERROR_CLASS:
-                        case H5I_ERROR_MSG:
-                        case H5I_ERROR_STACK:
-                        case H5I_NTYPES:
-                        default:
-                            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL,
-                                            "loc_id object is not a group, datatype or dataset");
-                    } /* end switch */
+                    if (url_len >= URL_MAX_LENGTH)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL,
+                                        "H5Oget_info_by_name request URL size exceeded maximum URL size");
 
                     break;
                 } /* H5VL_OBJECT_BY_NAME */
@@ -512,8 +418,7 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
 
                     htri_t      search_ret;
                     char        temp_URI[URI_MAX_LENGTH];
-                    const char *request_idx_type       = NULL;
-                    const char *parent_obj_type_header = NULL;
+                    const char *request_idx_type = NULL;
 
                     obj_type = H5I_UNINIT;
 
@@ -561,63 +466,26 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                     if (!search_ret || search_ret < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_PATH, FAIL, "can't locate parent object");
 
-                    /* Setup the host header */
-                    host_header_len = strlen(loc_obj->domain->u.file.filepath_name) + strlen(host_string) + 1;
-                    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL,
-                                        "can't allocate space for request Host header");
+                    if (RV_set_object_type_header(obj_type, &parent_obj_type_header) < 0)
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL,
+                                        "parent object not a group, datatype or dataset");
 
-                    strcpy(host_header, host_string);
-
-                    curl_headers = curl_slist_append(
-                        curl_headers, strncat(host_header, loc_obj->domain->u.file.filepath_name,
-                                              host_header_len - strlen(host_string) - 1));
-
-                    /* Disable use of Expect: 100 Continue HTTP response */
-                    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-                    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s/links?%s", base_URL,
-                                            temp_URI, request_idx_type)) < 0)
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s/links?%s",
+                                            parent_obj_type_header, temp_URI, request_idx_type)) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "attribute open URL exceeded maximum URL size");
 
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_USERNAME,
-                                                     loc_obj->domain->u.file.server_info.username))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_PASSWORD,
-                                                     loc_obj->domain->u.file.server_info.password))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL,
-                                        "can't set up cURL to make HTTP GET request: %s", curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
-                                        curl_err_buf);
-
-                    CURL_PERFORM(curl, H5E_LINK, H5E_CANTGET, FAIL);
+                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                                    loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
                     if (0 > RV_parse_response(response_buffer.buffer,
                                               (void *)&loc_params->loc_data.loc_by_idx, &found_object_name,
                                               RV_copy_link_name_by_index))
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_PARSEERROR, FAIL, "failed to retrieve link names");
-
-                    if (host_header) {
-                        RV_free(host_header);
-                        host_header = NULL;
-                    }
-
-                    if (curl_headers) {
-                        curl_slist_free_all(curl_headers);
-                        curl_headers = NULL;
-                    } /* end if */
 
                     /* Use name of link to get object URI for final request */
 
@@ -636,7 +504,7 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL,
                                         "object at index not a group, datatype or dataset");
 
-                    if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/%s/%s", base_URL,
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s",
                                             parent_obj_type_header, loc_info_out.URI)) < 0)
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_SYSERRSTR, FAIL, "snprintf error");
 
@@ -653,47 +521,9 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
             } /* end switch */
 
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
-
-            /* Setup the host header */
-            host_header_len = strlen(loc_info_out.domain->u.file.filepath_name) + strlen(host_string) + 1;
-            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTALLOC, FAIL,
-                                "can't allocate space for request Host header");
-
-            strcpy(host_header, host_string);
-
-            curl_headers = curl_slist_append(curl_headers,
-                                             strncat(host_header, loc_info_out.domain->u.file.filepath_name,
-                                                     host_header_len - strlen(host_string) - 1));
-
-            /* Disable use of Expect: 100 Continue HTTP response */
-            curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
-                                curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTSET, FAIL,
-                                "can't set up cURL to make HTTP GET request: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
-                                curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-            printf("-> Retrieving object info using URL: %s\n\n", request_url);
-
-            printf("   /**********************************\\\n");
-            printf("-> | Making GET request to the server |\n");
-            printf("   \\**********************************/\n\n");
-#endif
-
-            CURL_PERFORM(curl, H5E_OBJECT, H5E_CANTGET, FAIL);
+            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                            loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
+                FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTGET, FAIL, "can't get object");
 
             /* Retrieve the attribute count for the object */
             if (RV_parse_response(response_buffer.buffer, NULL, obj_info, RV_get_object_info_callback) < 0)
@@ -718,14 +548,6 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
     } /* end switch */
 
 done:
-    if (host_header)
-        RV_free(host_header);
-
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    } /* end if */
-
     if (found_object_name) {
         RV_free(found_object_name);
         found_object_name = NULL;
@@ -764,11 +586,8 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
     RV_object_t       *attr_object    = NULL;
     hid_t              iter_object_id = H5I_INVALID_HID;
     char               visit_by_name_URI[URI_MAX_LENGTH];
-    char               request_url[URL_MAX_LENGTH];
-    char              *host_header     = NULL;
-    int                url_len         = 0;
-    size_t             host_header_len = 0;
-
+    char               request_endpoint[URL_MAX_LENGTH];
+    int                url_len = 0;
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received object-specific call with following parameters:\n");
     printf("     - Object-specific call type: %s\n", object_specific_type_to_string(args->op_type));
@@ -1041,8 +860,7 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
             /* To build object table, information about parent object will be needed */
             object_iter_data.iter_obj_parent = iter_object;
 
-            if (url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/%s/%s",
-                                   iter_object->domain->u.file.server_info.base_URL, object_type_header,
+            if (url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s", object_type_header,
                                    object_iter_data.iter_obj_parent->URI) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
@@ -1093,54 +911,9 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
             /* Unlike H5Lvisit, H5Ovisit executes the provided callback on the directly specified object. */
 
             /* Make GET request to server */
-
-            /* Setup the host header */
-            host_header_len = strlen(object_iter_data.iter_obj_parent->domain->u.file.filepath_name) +
-                              strlen(host_string) + 1;
-            if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL,
-                                "can't allocate space for request Host header");
-
-            strcpy(host_header, host_string);
-
-            curl_headers = curl_slist_append(
-                curl_headers,
-                strncat(host_header, object_iter_data.iter_obj_parent->domain->u.file.filepath_name,
-                        host_header_len - strlen(host_string) - 1));
-
-            /* Disable use of Expect: 100 Continue HTTP response */
-            curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_USERNAME, loc_obj->domain->u.file.server_info.username))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s", curl_err_buf);
-            if (CURLE_OK !=
-                curl_easy_setopt(curl, CURLOPT_PASSWORD, loc_obj->domain->u.file.server_info.password))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s", curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set up cURL to make HTTP GET request: %s",
-                                curl_err_buf);
-            if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL request URL: %s", curl_err_buf);
-
-#ifdef RV_CONNECTOR_DEBUG
-            printf("-> Retrieving all links in group using URL: %s\n\n", request_url);
-
-            printf("   /**********************************\\\n");
-            printf("-> | Making GET request to the server |\n");
-            printf("   \\**********************************/\n\n");
-#endif
-
-            /* Do a first request to populate obj info in order to execute the callback on the top-level given
-             * object */
-            CURL_PERFORM(curl, H5E_LINK, H5E_CANTGET, FAIL);
-
-            if (curl_headers) {
-                curl_slist_free_all(curl_headers);
-                curl_headers = NULL;
-            }
+            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                            loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link to object");
 
             if (RV_parse_response(response_buffer.buffer, NULL, &oinfo, RV_get_object_info_callback) < 0)
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "failed to get object info");
@@ -1161,38 +934,18 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
             switch (iter_object_type) {
                 case H5I_FILE:
                 case H5I_GROUP:
-                    if (url_len =
-                            snprintf(request_url, URL_MAX_LENGTH, "%s/%s/%s%s",
-                                     object_iter_data.iter_obj_parent->domain->u.file.server_info.base_URL,
-                                     object_type_header, object_iter_data.iter_obj_parent->URI,
-                                     (!strcmp(object_type_header, "groups") ? "/links" : "")) < 0)
+                    if (url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/%s/%s%s", object_type_header,
+                                           object_iter_data.iter_obj_parent->URI,
+                                           (!strcmp(object_type_header, "groups") ? "/links" : "")) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "H5Oiterate/visit request URL size exceeded maximum URL size");
 
-                    curl_headers = curl_slist_append(curl_headers, host_header);
-
-                    /* Disable use of Expect: 100 Continue HTTP response */
-                    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPGET, 1))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL,
-                                        "can't set up cURL to make HTTP GET request: %s", curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
-                                        curl_err_buf);
-
-                    CURL_PERFORM(curl, H5E_LINK, H5E_CANTGET, FAIL);
-
-                    if (curl_headers) {
-                        curl_slist_free_all(curl_headers);
-                        curl_headers = NULL;
-                    }
+                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                                    loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
+                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link to object");
 
                     if (RV_parse_response(response_buffer.buffer, &object_iter_data, NULL,
                                           RV_object_iter_callback) < 0)
@@ -1226,9 +979,6 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
     } /* end switch */
 
 done:
-    if (host_header)
-        RV_free(host_header);
-
     RV_free(attr_loc_params);
 
     if (attr_object)
@@ -1587,12 +1337,12 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
     char               *visit_buffer = NULL;
     char               *link_section_start, *link_section_end;
     char               *url_encoded_link_name = NULL;
-    char                request_url[URL_MAX_LENGTH];
-    herr_t              ret_value   = SUCCEED;
-    int                 url_len     = 0;
-    H5I_type_t          obj_type    = H5I_UNINIT;
-    char               *host_header = NULL;
-    RV_object_t        *subgroup    = NULL;
+    char                request_endpoint[URL_MAX_LENGTH];
+    herr_t              ret_value = SUCCEED;
+    int                 url_len   = 0;
+    H5I_type_t          obj_type  = H5I_UNINIT;
+    RV_object_t        *subgroup  = NULL;
+    long                response_code;
 
     if (!HTTP_response)
         FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "HTTP response was NULL");
@@ -1810,72 +1560,21 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
                                      curl, H5_rest_basename(YAJL_GET_STRING(link_field_obj)), 0)))
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTENCODE, FAIL, "can't URL-encode link name");
 
-                    if ((url_len =
-                             snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s/links",
-                                      object_iter_data->iter_obj_parent->domain->u.file.server_info.base_URL,
-                                      url_encoded_link_name)) < 0)
+                    if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH, "/groups/%s/links",
+                                            url_encoded_link_name)) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "link GET request URL size exceeded maximum URL size");
 
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_URL, request_url))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL request URL: %s",
-                                        curl_err_buf);
+                    response_code = RV_curl_get(
+                        &object_iter_data->iter_obj_parent->domain->u.file.server_info, request_endpoint,
+                        object_iter_data->iter_obj_parent->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
 
-                    /* Set up host header */
-                    if (host_header) {
-                        RV_free(host_header);
-                        host_header = NULL;
-                    }
-
-                    if (curl_headers) {
-                        curl_slist_free_all(curl_headers);
-                        curl_headers = NULL;
-                    }
-
-                    size_t host_header_len =
-                        strlen(object_iter_data->iter_obj_parent->domain->u.file.filepath_name) +
-                        strlen(host_string) + 1;
-                    if (NULL == (host_header = (char *)RV_malloc(host_header_len)))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL,
-                                        "can't allocate space for request Host header");
-
-                    strcpy(host_header, host_string);
-
-                    curl_headers = curl_slist_append(
-                        curl_headers,
-                        strncat(host_header, object_iter_data->iter_obj_parent->domain->u.file.filepath_name,
-                                host_header_len - strlen(host_string) - 1));
-
-                    /* Disable use of Expect: 100 Continue HTTP response */
-                    curl_headers = curl_slist_append(curl_headers, "Expect:");
-
-                    if (CURLE_OK !=
-                        curl_easy_setopt(
-                            curl, CURLOPT_USERNAME,
-                            object_iter_data->iter_obj_parent->domain->u.file.server_info.username))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL username: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK !=
-                        curl_easy_setopt(
-                            curl, CURLOPT_PASSWORD,
-                            object_iter_data->iter_obj_parent->domain->u.file.server_info.password))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL password: %s",
-                                        curl_err_buf);
-                    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_headers))
-                        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set cURL HTTP headers: %s",
-                                        curl_err_buf);
-#ifdef RV_CONNECTOR_DEBUG
-                    printf("-> Retrieving all links in subgroup using URL: %s\n\n", request_url);
-
-                    printf("   /**********************************\\\n");
-                    printf("-> | Making GET request to the server |\n");
-                    printf("   \\**********************************/\n\n");
-#endif
-
-                    CURL_PERFORM(curl, H5E_LINK, H5E_CANTGET, FAIL);
+                    if (!(HTTP_SUCCESS(response_code)))
+                        FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTGET, FAIL, "can't get object: HTTP %ld",
+                                        response_code);
 
                     /* Use the group we are recursing into as the parent during the recursion */
                     if ((subgroup = RV_malloc(sizeof(RV_object_t))) == NULL)
@@ -1926,15 +1625,6 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
 
         /* Continue on to the next link subsection */
         link_section_start = link_section_end + 1;
-
-        if (host_header) {
-            RV_free(host_header);
-            host_header = NULL;
-        }
-        if (curl_headers) {
-            curl_slist_free_all(curl_headers);
-            curl_headers = NULL;
-        }
     } /* end for */
 
 #ifdef RV_CONNECTOR_DEBUG
@@ -1963,12 +1653,6 @@ done:
         yajl_tree_free(parse_tree);
     if (visit_buffer)
         RV_free(visit_buffer);
-    if (host_header)
-        RV_free(host_header);
-    if (curl_headers) {
-        curl_slist_free_all(curl_headers);
-        curl_headers = NULL;
-    }
 
     return ret_value;
 } /* end RV_build_object_table */

--- a/src/rest_vol_object.c
+++ b/src/rest_vol_object.c
@@ -478,7 +478,7 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "attribute open URL exceeded maximum URL size");
 
-                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                    if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                     loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link");
 
@@ -521,7 +521,7 @@ RV_object_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_get_ar
             } /* end switch */
 
             /* Make a GET request to the server to retrieve the number of attributes attached to the object */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTGET, FAIL, "can't get object");
 
@@ -911,7 +911,7 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
             /* Unlike H5Lvisit, H5Ovisit executes the provided callback on the directly specified object. */
 
             /* Make GET request to server */
-            if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+            if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                             loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link to object");
 
@@ -943,7 +943,7 @@ RV_object_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_object_s
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "H5Oiterate/visit request URL size exceeded maximum URL size");
 
-                    if (RV_curl_get(&loc_obj->domain->u.file.server_info, request_endpoint,
+                    if (RV_curl_get(curl, &loc_obj->domain->u.file.server_info, request_endpoint,
                                     loc_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTGET, FAIL, "can't get link to object");
 
@@ -1569,8 +1569,9 @@ RV_build_object_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func
                                         "link GET request URL size exceeded maximum URL size");
 
                     response_code = RV_curl_get(
-                        &object_iter_data->iter_obj_parent->domain->u.file.server_info, request_endpoint,
-                        object_iter_data->iter_obj_parent->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
+                        curl, &object_iter_data->iter_obj_parent->domain->u.file.server_info,
+                        request_endpoint, object_iter_data->iter_obj_parent->domain->u.file.filepath_name,
+                        CONTENT_TYPE_JSON);
 
                     if (!(HTTP_SUCCESS(response_code)))
                         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTGET, FAIL, "can't get object: HTTP %ld",


### PR DESCRIPTION
Most curl requests are now done through new helper functions in `rest_vol.c`, `RV_curl_post`, `RV_curl_put` `RV_curl_delete`, and `RV_curl_get`. These functions each create a local curl handle, perform the request, then clean up the handle afterwards.

In order to allow for cases where specific error codes are OK or even expected (checking for the existence of files, flush requests that expect to get HTTP 204 NO CONTENT) the curl helpers return the HTTP code that the request returned, or -1 if the request failed.

The curl helper functions take in the server's base URL through the `server_info_t` struct, so they only need the endpoint as a separate argument. For this reason, most instances of `request_url` have been changed to `request_endpoint`, and no longer include the base URL. This `request_endpoint` is what is passed to the curl helpers.

I also introduced a new global variable `H5_rest_curl_initialized_g` to track if curl is initialized. This avoids not-initializing or double-initializing it in the new helper to create a curl handle, `RV_curl_setup_handle`.

Places that still use the global curl handle:
- `H5_rest_authenticate_with_AD` since I'm not sure how to test it
- dataset read/writes via `RV_curl_multi_perform`

This is a draft PR since it's based on the branch that stores server connection information on individual file objects (#86).