### PR TITLE
Implement H5Arename/H5Arename_by_name by copy

### DIFF
--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -2887,20 +2887,20 @@ done:
             case H5I_FILE:
             case H5I_GROUP:
                 if (RV_group_close((void *)attr_parent, H5P_DEFAULT, NULL) < 0)
-                    FUNC_GOTO_ERROR(H5E_SYM, H5E_CANTCLOSEOBJ, FAIL, "can't close parent group");
+                    FUNC_DONE_ERROR(H5E_SYM, H5E_CANTCLOSEOBJ, FAIL, "can't close parent group");
                 break;
 
             case H5I_DATASET:
                 if (RV_dataset_close((void *)attr_parent, H5P_DEFAULT, NULL) < 0)
-                    FUNC_GOTO_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close parent dataset");
+                    FUNC_DONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close parent dataset");
                 break;
 
             case H5I_DATATYPE:
                 if (RV_datatype_close((void *)attr_parent, H5P_DEFAULT, NULL) < 0)
-                    FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close parent datatype");
+                    FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close parent datatype");
 
             default:
-                FUNC_GOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
+                FUNC_DONE_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
                                 "attribute's parent object is not group, dataset, or datatype");
                 break;
         }

--- a/test/test_rest_vol.c
+++ b/test/test_rest_vol.c
@@ -5744,10 +5744,10 @@ test_create_dataset_predefined_types(void)
     hid_t  fspace_id                    = -1;
     hid_t  dset_id                      = -1;
     hid_t  predefined_type_test_table[] = {H5T_STD_U8LE,   H5T_STD_U8BE,   H5T_STD_I8LE,   H5T_STD_I8BE,
-                                           H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
-                                           H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
-                                           H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
-                                           H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
+                                          H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
+                                          H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
+                                          H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
+                                          H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
 
     TESTING("dataset creation w/ predefined datatypes")
 


### PR DESCRIPTION
This PR implements `H5Arename(_by_name)` by creating a new attribute of the desired name, copying the information, and deleting the old attribute.

The `H5Arename` test was removed from `test_rest_vol.c` because it would occasionally generate invalid datatypes for HSDS; the `H5Arename` tests in `vol-tests` are used to test this function.

