### PR TITLE
Fix segfault on VOL termination

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -99,7 +99,7 @@ typedef struct H5_rest_ad_info_t {
 } H5_rest_ad_info_t;
 
 /* Global array containing information about open objects */
-RV_type_info *RV_type_info_array_g[H5I_MAX_NUM_TYPES];
+RV_type_info *RV_type_info_array_g[H5I_MAX_NUM_TYPES] = {0};
 
 /* Host header string for specifying the host (Domain) for requests */
 const char *const host_string = "X-Hdf-domain: ";

--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -629,11 +629,16 @@ H5_rest_term(void)
     } /* end if */
 
     /* Cleanup type info array */
-    for (size_t i = 0; i < H5I_MAX_NUM_TYPES; i++) {
-        rv_hash_table_free(RV_type_info_array_g[i]->table);
-        RV_free(RV_type_info_array_g[i]);
-        RV_type_info_array_g[i] = NULL;
+    if (RV_type_info_array_g) {
+        for (size_t i = 0; i < H5I_MAX_NUM_TYPES; i++) {
+            if (RV_type_info_array_g[i]) {
+                rv_hash_table_free(RV_type_info_array_g[i]->table);
+                RV_free(RV_type_info_array_g[i]);
+                RV_type_info_array_g[i] = NULL;
+            }
+        }
     }
+
     /*
      * "Forget" connector ID. This should normally be called by the library
      * when it is closing the id, so no need to close it here.


### PR DESCRIPTION
Sometimes the global type array `RV_type_info_array_g` can have a NULL value, and if it did, the VOL termination would attempt to dereference a NULL pointer while freeing it. It now checks that the array exists before trying to free it.

I'm not exactly sure what factors cause the array to be NULL - it's declared in `rest_vol.h`, defined in `rest_vol.c`, and never explicitly set to NULL. This issue didn't come up with the dynamically linked or manually linked tests on their own - it only cropped up when using the manually linked tests (`test_rest_vol`) when they were built under the library with fetch content, and when running them through the autotools-generated script.