### PR TITLE
Handle compound type subsetting for dataset read/writes

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -428,12 +428,21 @@ typedef struct RV_type_info {
     rv_hash_table_t *table;
 } RV_type_info;
 
+/* Copy of H5T_subset_t struct defn for compound subsetting */
+typedef enum {
+    H5T_SUBSET_BADVALUE = -1, /* Invalid value */
+    H5T_SUBSET_FALSE    = 0,  /* Source and destination aren't subset of each other */
+    H5T_SUBSET_SRC,           /* Source is the subset of dest and no conversion is needed */
+    H5T_SUBSET_DST,           /* Dest is the subset of source and no conversion is needed */
+    H5T_SUBSET_CAP            /* Must be the last value */
+} RV_subset_t;
+
 /* Information about members of a compound type for subsetting */
 typedef struct RV_compound_info_t {
     int     nmembers; /* Number of offset/length pairs used */
     int     nalloc;   /* Number of offset/length pairs allocated */
-    size_t *mem_offsets;
-    size_t *file_offsets;
+    size_t *src_offsets;
+    size_t *dst_offsets;
     size_t *lengths;
 } RV_compound_info_t;
 
@@ -771,7 +780,7 @@ herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type
                                    server_api_version server_version);
 
 /* Determine if a read from file to mem dtype is a compound subset read */
-htri_t RV_is_compound_subset_read(hid_t mem_type_id, hid_t file_type_id);
+herr_t RV_get_compound_subset_info(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subset_info);
 
 /* Helper to get information about fields that are unused due to compound subsetting */
 herr_t RV_get_unused_compound_fields(hid_t mem_type_id, hid_t file_type_id,

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -428,11 +428,12 @@ typedef struct RV_type_info {
     rv_hash_table_t *table;
 } RV_type_info;
 
-/* Information about members of a compound type */
+/* Information about members of a compound type for subsetting */
 typedef struct RV_compound_info_t {
     int     nmembers; /* Number of offset/length pairs used */
     int     nalloc;   /* Number of offset/length pairs allocated */
-    size_t *offsets;
+    size_t *mem_offsets;
+    size_t *file_offsets;
     size_t *lengths;
 } RV_compound_info_t;
 

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -761,6 +761,9 @@ herr_t RV_tconv_init(hid_t src_type_id, size_t *src_type_size, hid_t dst_type_id
 herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type_body_len, hbool_t nested,
                                    server_api_version server_version);
 
+/* Determine if a read from file to mem dtype is a compound subset read */
+htri_t RV_is_compound_subset_read(hid_t mem_type_id, hid_t file_type_id);
+
 /* Helper function to escape control characters for JSON strings */
 herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);
 

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -786,6 +786,10 @@ herr_t RV_get_compound_subset_info(hid_t src_type_id, hid_t dst_type_id, RV_subs
 herr_t RV_get_unused_compound_fields(hid_t mem_type_id, hid_t file_type_id,
                                      RV_compound_info_t *compound_info);
 
+/* Helper function to handle compound type subsetting during reads. */
+herr_t RV_handle_compound_subset_read(hid_t src_type_id, hid_t dst_type_id, hid_t dst_space_id,
+                                      const void *src_buf, void *dst_buf);
+
 /* Helper function to escape control characters for JSON strings */
 herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);
 

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -428,6 +428,14 @@ typedef struct RV_type_info {
     rv_hash_table_t *table;
 } RV_type_info;
 
+/* Information about members of a compound type */
+typedef struct RV_compound_info_t {
+    int     nmembers; /* Number of offset/length pairs used */
+    int     nalloc;   /* Number of offset/length pairs allocated */
+    size_t *offsets;
+    size_t *lengths;
+} RV_compound_info_t;
+
 /* TODO - This is copied directly from the library */
 #define TYPE_BITS         7
 #define TYPE_MASK         (((hid_t)1 << TYPE_BITS) - 1)
@@ -763,6 +771,10 @@ herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type
 
 /* Determine if a read from file to mem dtype is a compound subset read */
 htri_t RV_is_compound_subset_read(hid_t mem_type_id, hid_t file_type_id);
+
+/* Helper to get information about fields that are unused due to compound subsetting */
+herr_t RV_get_unused_compound_fields(hid_t mem_type_id, hid_t file_type_id,
+                                     RV_compound_info_t *compound_info);
 
 /* Helper function to escape control characters for JSON strings */
 herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -782,13 +782,18 @@ herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type
 /* Determine if a read from file to mem dtype is a compound subset read */
 herr_t RV_get_compound_subset_info(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subset_info);
 
-/* Helper to get information about fields that are unused due to compound subsetting */
-herr_t RV_get_unused_compound_fields(hid_t mem_type_id, hid_t file_type_id,
-                                     RV_compound_info_t *compound_info);
+/* Helper to get information about members in dst that are omitted in src due to compound subsetting */
+herr_t RV_get_omitted_compound_members(hid_t src_type_id, hid_t dst_type_id,
+                                       RV_compound_info_t *compound_info);
 
-/* Helper function to handle compound type subsetting during reads. */
+/* Helper function to handle compound type subsetting during reads */
 herr_t RV_handle_compound_subset_read(hid_t src_type_id, hid_t dst_type_id, hid_t dst_space_id,
                                       const void *src_buf, void *dst_buf);
+
+/* Helper function to handle compound type subsetting during writes */
+herr_t RV_handle_compound_subset_write(hid_t src_type_id, hid_t dst_type_id, hid_t src_space_id,
+                                       hid_t dst_space_id, RV_object_t *dset, const void *buf_in,
+                                       void *buf_out);
 
 /* Helper function to escape control characters for JSON strings */
 herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);

--- a/src/rest_vol_attr.c
+++ b/src/rest_vol_attr.c
@@ -216,7 +216,7 @@ RV_attr_create(void *obj, const H5VL_loc_params_t *loc_params, const char *attr_
 
     /* Form the Datatype portion of the Attribute create request */
     if (RV_convert_datatype_to_JSON(type_id, &datatype_body, &datatype_body_len, FALSE,
-                                    parent->domain->u.file.server_version) < 0)
+                                    parent->domain->u.file.server_info.version) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, NULL,
                         "can't convert attribute's datatype to JSON representation");
 


### PR DESCRIPTION
This should be done for attributes too eventually, but only datasets are checked in the vol tests.

Fix for #21