### PR TITLE
Support link names up to 64Kb

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -770,6 +770,8 @@ herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type
 #define SERVER_VERSION_SUPPORTS_FIXED_LENGTH_UTF8(version)                                                   \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
 
+#define SERVER_VERSION_SUPPORTS_LONG_URLS(version) (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -79,11 +79,11 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     char        *datatype_body         = NULL;
     char        *link_body             = NULL;
     char        *path_dirname          = NULL;
-    char         request_url[URL_MAX_LENGTH];
-    int          commit_request_len = 0;
-    int          link_body_len      = 0;
-    int          url_len            = 0;
-    void        *ret_value          = NULL;
+    char        *request_url           = NULL;
+    int          commit_request_len    = 0;
+    int          link_body_len         = 0;
+    int          url_len               = 0;
+    void        *ret_value             = NULL;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Received datatype commit call with following parameters:\n");
@@ -243,6 +243,9 @@ RV_datatype_commit(void *obj, const H5VL_loc_params_t *loc_params, const char *n
     /* Instruct cURL that we are sending JSON */
     curl_headers = curl_slist_append(curl_headers, "Content-Type: application/json");
 
+    if ((request_url = RV_malloc(strlen(base_URL) + strlen("/datatypes") + 1)) == NULL)
+        FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTALLOC, NULL, "can't allocate space for request url");
+
     /* Redirect cURL from the base URL to "/datatypes" to commit the datatype */
     if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/datatypes", base_URL)) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_SYSERRSTR, NULL, "snprintf error");
@@ -313,6 +316,8 @@ done:
         RV_free(datatype_body);
     if (link_body)
         RV_free(link_body);
+    if (request_url)
+        RV_free(request_url);
 
     /* Clean up allocated datatype object if there was an issue */
     if (new_datatype && !ret_value)

--- a/src/rest_vol_link.c
+++ b/src/rest_vol_link.c
@@ -330,6 +330,11 @@ RV_link_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_t
                             new_link_loc_obj->URI, url_encoded_link_name)) < 0)
         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(new_link_loc_obj->domain->u.file.server_version)) &&
+        (url_len >= OLD_URL_MAX_LENGTH))
+        FUNC_GOTO_ERROR(H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                        "URL with length > 2048 not supported by server versions before 0.8.5");
+
     if (url_len >= URL_MAX_LENGTH)
         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "link create URL size exceeded maximum URL size");
 
@@ -542,6 +547,12 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
                         0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+                    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                        (url_len >= OLD_URL_MAX_LENGTH))
+                        FUNC_GOTO_ERROR(
+                            H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                            "URL with length > 2048 not supported by server versions before 0.8.5");
+
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "H5Lget_info request URL size exceeded maximum URL size");
@@ -653,6 +664,11 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
                 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+            if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                (url_len >= OLD_URL_MAX_LENGTH))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                                "URL with length > 2048 not supported by server versions before 0.8.5");
+
             if (url_len >= URL_MAX_LENGTH)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                 "H5Lget_name_by_idx request URL size exceeded maximum URL size");
@@ -759,6 +775,12 @@ RV_link_get(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_get_args_t
                                             empty_dirname ? loc_obj->URI : temp_URI, url_encoded_link_name)) <
                         0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+
+                    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                        (url_len >= OLD_URL_MAX_LENGTH))
+                        FUNC_GOTO_ERROR(
+                            H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                            "URL with length > 2048 not supported by server versions before 0.8.5");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
@@ -938,6 +960,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                         0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+                    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                        (url_len >= OLD_URL_MAX_LENGTH))
+                        FUNC_GOTO_ERROR(
+                            H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                            "URL with length > 2048 not supported by server versions before 0.8.5");
+
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "H5Ldelete request URL size exceeded maximum URL size");
@@ -1036,6 +1064,11 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                                     empty_dirname ? loc_obj->URI : temp_URI, url_encoded_link_name)) < 0)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+            if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                (url_len >= OLD_URL_MAX_LENGTH))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                                "URL with length > 2048 not supported by server versions before 0.8.5");
+
             if (url_len >= URL_MAX_LENGTH)
                 FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                 "H5Lexists request URL size exceeded maximum URL size");
@@ -1121,6 +1154,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                                             loc_obj->URI)) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
 
+                    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                        (url_len >= OLD_URL_MAX_LENGTH))
+                        FUNC_GOTO_ERROR(
+                            H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                            "URL with length > 2048 not supported by server versions before 0.8.5");
+
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
                                         "H5Literate/visit request URL size exceeded maximum URL size");
@@ -1156,6 +1195,12 @@ RV_link_specific(void *obj, const H5VL_loc_params_t *loc_params, H5VL_link_speci
                     if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s/links", base_URL,
                                             ((RV_object_t *)link_iter_group_object)->URI)) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+
+                    if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(loc_obj->domain->u.file.server_version)) &&
+                        (url_len >= OLD_URL_MAX_LENGTH))
+                        FUNC_GOTO_ERROR(
+                            H5E_LINK, H5E_UNSUPPORTED, FAIL,
+                            "URL with length > 2048 not supported by server versions before 0.8.5");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(
@@ -2019,6 +2064,11 @@ RV_build_link_table(char *HTTP_response, hbool_t is_recursive, int (*sort_func)(
                     if ((url_len = snprintf(request_url, URL_MAX_LENGTH, "%s/groups/%s/links", base_URL,
                                             url_encoded_link_name)) < 0)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+
+                    // if (!(SERVER_VERSION_SUPPORTS_LONG_URLS(???->domain->u.file.server_version))
+                    //     && (url_len >= OLD_URL_MAX_LENGTH))
+                    //     FUNC_GOTO_ERROR(H5E_LINK, H5E_UNSUPPORTED, FAIL, "URL with length > 2048 not
+                    //     supported by server versions before 0.8.5");
 
                     if (url_len >= URL_MAX_LENGTH)
                         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,

--- a/src/rest_vol_public.h
+++ b/src/rest_vol_public.h
@@ -27,6 +27,9 @@
  */
 #define URL_MAX_LENGTH ((64 * 1024) + 1024) + 2048
 
+/* Maximum URL length supported by server API versions <= 0.8.4 */
+#define OLD_URL_MAX_LENGTH 2048
+
 /* Maximum length in characters of the URI of an object as returned by the server. If the
  * server in question returns URIs which are longer than this, the value will have to be
  * adjusted. Otherwise, the URIs will be truncated and invalid, likely causing severe

--- a/src/rest_vol_public.h
+++ b/src/rest_vol_public.h
@@ -25,7 +25,7 @@
  * this VOL connector. If the URLs used in operation are longer than this, the value will have
  * to be adjusted. Otherwise, the URLs will be truncated.
  */
-#define URL_MAX_LENGTH 2048
+#define URL_MAX_LENGTH ((64 * 1024) + 1024) + 2048
 
 /* Maximum length in characters of the URI of an object as returned by the server. If the
  * server in question returns URIs which are longer than this, the value will have to be


### PR DESCRIPTION
Moved the URL for cURL requests to the heap to support longer URLs. 

The specific new value of `URL_MAX_LENGTH`, `((64 * 1024) + 1024) + 2048` is the maximum tested link length in the API tests (`64 * 1024 + 1024`) plus the maximum expected length of the rest of a URL (`2048`).

Requires HSDS to support long URLs, which is implemented in HDFGroup/hsds#294. This is a draft PR until that gets into master. 