### PR TITLE
Support long links with HSDS >0.8.5

### DIFF
--- a/src/rest_vol.c
+++ b/src/rest_vol.c
@@ -141,6 +141,9 @@ const char *attributes_keys[] = {"attributes", (const char *)0};
 /* JSON keys to retrieve allocated size */
 const char *allocated_size_keys[] = {"allocated_size", (const char *)0};
 
+/* JSON keys to retrieve objects accessed through path(s) */
+const char *h5paths_keys[] = {"h5paths", (const char *)0};
+
 /* Default size for the buffer to allocate during base64-encoding if the caller
  * of RV_base64_encode supplies a 0-sized buffer.
  */
@@ -1681,10 +1684,12 @@ done:
 herr_t
 RV_parse_object_class(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
-    yajl_val    parse_tree = NULL, key_obj;
+    yajl_val    parse_tree = NULL, key_obj = NULL, class_obj = NULL, target_tree = NULL;
     char       *parsed_object_string;
-    H5I_type_t *object_type = (H5I_type_t *)callback_data_out;
-    herr_t      ret_value   = SUCCEED;
+    const char *object_class_keys[] = {"class", (const char *)0};
+    const char *path_name           = NULL;
+    H5I_type_t *object_type         = (H5I_type_t *)callback_data_out;
+    herr_t      ret_value           = SUCCEED;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Retrieving object's class from server's HTTP response\n\n");
@@ -1698,9 +1703,25 @@ RV_parse_object_class(char *HTTP_response, const void *callback_data_in, void *c
     if (NULL == (parse_tree = yajl_tree_parse(HTTP_response, NULL, 0)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsing JSON failed");
 
-    const char *object_class_keys[] = {"class", (const char *)0};
+    target_tree = parse_tree;
 
-    if (NULL == (key_obj = yajl_tree_get(parse_tree, object_class_keys, yajl_t_string))) {
+    /* If the response contains 'h5paths',
+     * it may describe multiple objects. Needs to be unwrapped first. */
+    if (NULL != yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)) {
+        if (NULL == (key_obj = yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "can't parse h5paths object");
+
+        /* Access the first object under h5paths */
+        if (NULL == (path_name = key_obj->u.object.keys[0]))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsed path name was NULL");
+
+        const char *path_keys[] = {path_name, (const char *)0};
+
+        if (NULL == (target_tree = yajl_tree_get(key_obj, path_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "unable to parse object under path key");
+    }
+
+    if (NULL == (key_obj = yajl_tree_get(target_tree, object_class_keys, yajl_t_string))) {
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "couldn't parse object class");
     }
 
@@ -1852,10 +1873,11 @@ done:
 herr_t
 RV_copy_object_URI_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
-    yajl_val parse_tree = NULL, key_obj;
-    char    *parsed_string;
-    char    *buf_out   = (char *)callback_data_out;
-    herr_t   ret_value = SUCCEED;
+    yajl_val    parse_tree = NULL, key_obj = NULL, single_obj = NULL, target_tree = NULL;
+    char       *parsed_string;
+    char       *buf_out   = (char *)callback_data_out;
+    const char *path_name = NULL;
+    herr_t      ret_value = SUCCEED;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Retrieving object's URI from server's HTTP response\n\n");
@@ -1869,11 +1891,29 @@ RV_copy_object_URI_callback(char *HTTP_response, const void *callback_data_in, v
     if (NULL == (parse_tree = yajl_tree_parse(HTTP_response, NULL, 0)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsing JSON failed");
 
+    target_tree = parse_tree;
+
+    /* If the response contains 'h5paths',
+     * it may describe multiple objects. Needs to be unwrapped first. */
+    if (NULL != yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)) {
+        if (NULL == (target_tree = yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "can't parse h5paths object");
+
+        /* Access the first object under h5paths */
+        if (NULL == (path_name = target_tree->u.object.keys[0]))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsed path name was NULL");
+
+        const char *path_keys[] = {path_name, (const char *)0};
+
+        if (NULL == (target_tree = yajl_tree_get(target_tree, path_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "unable to parse object under path key");
+    }
+
     /* To handle the awkward case of soft and external links, which do not return an "ID",
      * first check for the link class field and short circuit if it is found to be
      * equal to "H5L_TYPE_SOFT"
      */
-    if (NULL != (key_obj = yajl_tree_get(parse_tree, link_class_keys, yajl_t_string))) {
+    if (NULL != (key_obj = yajl_tree_get(target_tree, link_class_keys, yajl_t_string))) {
         char *link_type;
 
         if (NULL == (link_type = YAJL_GET_STRING(key_obj)))
@@ -1887,7 +1927,7 @@ RV_copy_object_URI_callback(char *HTTP_response, const void *callback_data_in, v
     /* First attempt to retrieve the URI of the object by using the JSON key sequence
      * "link" -> "id", which is returned when making a GET Link request.
      */
-    key_obj = yajl_tree_get(parse_tree, link_id_keys, yajl_t_string);
+    key_obj = yajl_tree_get(target_tree, link_id_keys, yajl_t_string);
     if (key_obj) {
         if (!YAJL_IS_STRING(key_obj))
             FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "returned URI is not a string");
@@ -1909,7 +1949,7 @@ RV_copy_object_URI_callback(char *HTTP_response, const void *callback_data_in, v
          * for just the JSON key "id", which would generally correspond to trying to
          * retrieve the URI of a newly-created or opened object that isn't a file.
          */
-        key_obj = yajl_tree_get(parse_tree, object_id_keys, yajl_t_string);
+        key_obj = yajl_tree_get(target_tree, object_id_keys, yajl_t_string);
         if (key_obj) {
             if (!YAJL_IS_STRING(key_obj))
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "returned URI is not a string");
@@ -1932,7 +1972,7 @@ RV_copy_object_URI_callback(char *HTTP_response, const void *callback_data_in, v
              * retrieve the URI of a newly-created or opened file, or to a search for
              * the root group of a file.
              */
-            if (NULL == (key_obj = yajl_tree_get(parse_tree, root_id_keys, yajl_t_string)))
+            if (NULL == (key_obj = yajl_tree_get(target_tree, root_id_keys, yajl_t_string)))
                 FUNC_GOTO_ERROR(H5E_OBJECT, H5E_CANTGET, FAIL, "retrieval of URI failed");
 
             if (!YAJL_IS_STRING(key_obj))
@@ -2005,8 +2045,9 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
                        herr_t (*obj_found_callback)(char *, const void *, void *), void *callback_data_in,
                        void *callback_data_out)
 {
-    RV_object_t       *external_file    = NULL;
-    hbool_t            is_relative_path = FALSE;
+    RV_object_t       *external_file     = NULL;
+    hbool_t            is_relative_path  = FALSE;
+    size_t             escaped_path_size = 0;
     H5L_info2_t        link_info;
     char              *url_encoded_link_name = NULL;
     char              *path_dirname          = NULL;
@@ -2015,6 +2056,8 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
     const char        *ext_filename          = NULL;
     const char        *ext_obj_path          = NULL;
     char               request_endpoint[URL_MAX_LENGTH];
+    char              *escaped_obj_path = NULL;
+    char              *request_body     = NULL;
     long               http_response;
     int                url_len = 0;
     server_api_version version;
@@ -2090,15 +2133,34 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
     if (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 0)) {
 
         /* Set up request URL to make server do repeated traversal of symbolic links */
+        if (SERVER_VERSION_SUPPORTS_LONG_NAMES(version)) {
+            /* Send object path in body of POST request */
+            if (RV_JSON_escape_string(obj_path, escaped_obj_path, &escaped_path_size) < 0)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "can't get size of escaped object path");
 
-        if (NULL == (url_encoded_path_name = H5_rest_url_encode_path(obj_path)))
-            FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTENCODE, FAIL, "can't URL-encode object path");
+            if ((escaped_obj_path = RV_malloc(escaped_path_size)) == NULL)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL, "can't allocate space for escaped path");
 
-        if ((url_len = snprintf(request_endpoint, URL_MAX_LENGTH,
-                                "/?h5path=%s%s%s&follow_soft_links=1&follow_external_links=1",
-                                url_encoded_path_name, is_relative_path ? "&parent_id=" : "",
-                                is_relative_path ? parent_obj->URI : "")) < 0)
-            FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+            if (RV_JSON_escape_string(obj_path, escaped_obj_path, &escaped_path_size) < 0)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "can't escape object path");
+
+            if ((url_len = snprintf(request_url, URL_MAX_LENGTH,
+                                    "%s/?follow_soft_links=1&follow_external_links=1%s%s", base_URL,
+                                    is_relative_path ? "&parent_id=" : "",
+                                    is_relative_path ? parent_obj->URI : "")) < 0)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+        }
+        else {
+            /* Send object path in URL of GET request */
+            if (NULL == (url_encoded_path_name = H5_rest_url_encode_path(obj_path)))
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTENCODE, FAIL, "can't URL-encode object path");
+
+            if ((url_len = snprintf(request_url, URL_MAX_LENGTH,
+                                    "%s/?h5path=%s%s%s&follow_soft_links=1&follow_external_links=1", base_URL,
+                                    url_encoded_path_name, is_relative_path ? "&parent_id=" : "",
+                                    is_relative_path ? parent_obj->URI : "")) < 0)
+                FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+        }
     }
     else {
         /* Server will not traverse symbolic links for us */
@@ -2195,8 +2257,43 @@ RV_find_object_by_path(RV_object_t *parent_obj, const char *obj_path, H5I_type_t
     if (url_len >= URL_MAX_LENGTH)
         FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "Request URL size exceeded maximum URL size");
 
-    http_response = RV_curl_get(curl, &parent_obj->domain->u.file.server_info, request_endpoint,
-                                parent_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
+
+    /* Make POST request that supports long paths if server supports it.
+       Otherwise, make GET request */
+    if (SERVER_VERSION_SUPPORTS_LONG_NAMES(version)) {
+#ifdef RV_CONNECTOR_DEBUG
+        printf("   /**********************************\\\n");
+        printf("-> | Making GET request to the server |\n");
+        printf("   \\**********************************/\n\n");
+#endif
+
+        http_response = RV_curl_get(curl, &parent_obj->domain->u.file.server_info, request_endpoint,
+                                    parent_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON);
+    } else {
+#ifdef RV_CONNECTOR_DEBUG
+        printf("   /**********************************\\\n");
+        printf("-> | Making POST request to the server |\n");
+        printf("   \\**********************************/\n\n");
+#endif
+        const char *fmt_string       = "{\"h5paths\": [\"%s\"]}";
+        size_t      request_body_len = 0;
+        int         bytes_printed    = 0;
+
+        request_body_len = strlen(fmt_string) + strlen(escaped_obj_path) + 1;
+
+        if ((request_body = RV_malloc(request_body_len)) == NULL)
+            FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTALLOC, FAIL, "can't allocate space for path request body");
+
+        if ((bytes_printed = snprintf(request_body, request_body_len, fmt_string, escaped_obj_path)) < 0)
+            FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL, "snprintf error");
+
+        if (bytes_printed >= request_body_len)
+            FUNC_GOTO_ERROR(H5E_LINK, H5E_SYSERRSTR, FAIL,
+                            "request body size exceeded allocated buffer size");
+
+        http_response = RV_curl_post(curl, &parent_obj->domain->u.file.server_info, request_endpoint,
+                                     parent_obj->domain->u.file.filepath_name, CONTENT_TYPE_JSON)
+    }
 
     if (HTTP_SUCCESS(http_response))
         ret_value = TRUE;
@@ -2304,6 +2401,14 @@ done:
         curl_free(url_encoded_link_name);
     if (path_dirname)
         RV_free(path_dirname);
+    if (escaped_obj_path)
+        RV_free(escaped_obj_path);
+    if (request_body)
+        RV_free(request_body);
+
+    /* Necessary to prevent curl from potentially accessing freed buffers in subsequent calls */
+    if (CURLE_OK != curl_easy_setopt(curl, CURLOPT_POST, 0))
+        FUNC_GOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't unset cURL HTTP POST request: %s", curl_err_buf);
 
     if (external_file)
         if (RV_file_close(external_file, H5P_DEFAULT, NULL) < 0)
@@ -2387,11 +2492,12 @@ done:
 herr_t
 RV_copy_object_loc_info_callback(char *HTTP_response, const void *callback_data_in, void *callback_data_out)
 {
-    yajl_val             parse_tree = NULL, key_obj;
-    char                *parsed_string;
-    loc_info            *loc_info_out = (loc_info *)callback_data_out;
-    const server_info_t *server_info  = (const server_info_t *)callback_data_in;
-    herr_t               ret_value    = SUCCEED;
+    yajl_val       parse_tree = NULL, key_obj = NULL, target_tree = NULL;
+    char          *parsed_string = NULL;
+    const char    *path_name     = NULL;
+    loc_info      *loc_info_out  = (loc_info *)callback_data_out;
+    server_info_t *server_info   = (server_info_t *)callback_data_in;
+    herr_t         ret_value     = SUCCEED;
 
     char *GCPL_buf = NULL;
 
@@ -2414,10 +2520,27 @@ RV_copy_object_loc_info_callback(char *HTTP_response, const void *callback_data_
     if (NULL == (parse_tree = yajl_tree_parse(HTTP_response, NULL, 0)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsing JSON failed");
 
+    target_tree = parse_tree;
+
+    /* If the response contains 'h5paths',
+     * it may describe multiple objects. Needs to be unwrapped first. */
+    if (NULL != yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)) {
+        if (NULL == (target_tree = yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "can't parse h5paths object");
+
+        /* Access the first object under h5paths */
+        if (NULL == (path_name = target_tree->u.object.keys[0]))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsed path name was NULL");
+
+        const char *path_keys[] = {path_name, (const char *)0};
+
+        if (NULL == (target_tree = yajl_tree_get(target_tree, path_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "unable to parse object under path key");
+    }
     /* Not all objects have a creationProperties field, so fail this gracefully */
     H5E_BEGIN_TRY
     {
-        RV_parse_creation_properties_callback(parse_tree, &GCPL_buf);
+        RV_parse_creation_properties_callback(target_tree, &GCPL_buf);
     }
     H5E_END_TRY
 
@@ -2426,7 +2549,7 @@ RV_copy_object_loc_info_callback(char *HTTP_response, const void *callback_data_
     }
 
     /* Retrieve domain path */
-    if (NULL == (key_obj = yajl_tree_get(parse_tree, domain_keys, yajl_t_string)))
+    if (NULL == (key_obj = yajl_tree_get(target_tree, domain_keys, yajl_t_string)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "failed to parse domain");
 
     if (!YAJL_IS_STRING(key_obj))
@@ -2436,7 +2559,7 @@ RV_copy_object_loc_info_callback(char *HTTP_response, const void *callback_data_
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "domain was NULL");
 
     /* Retrieve domain id */
-    if (NULL == (key_obj = yajl_tree_get(parse_tree, root_id_keys, yajl_t_string)))
+    if (NULL == (key_obj = yajl_tree_get(target_tree, root_id_keys, yajl_t_string)))
         FUNC_GOTO_ERROR(H5E_OBJECT, H5E_BADVALUE, FAIL, "failed to parse domain id");
 
     if (!YAJL_IS_STRING(key_obj))
@@ -2733,12 +2856,13 @@ done:
 hid_t
 RV_parse_dataspace(char *space)
 {
-    yajl_val parse_tree = NULL, key_obj = NULL;
-    hsize_t *space_dims     = NULL;
-    hsize_t *space_maxdims  = NULL;
-    hid_t    dataspace      = FAIL;
-    char    *dataspace_type = NULL;
-    hid_t    ret_value      = FAIL;
+    yajl_val    parse_tree = NULL, key_obj = NULL, target_tree = NULL;
+    hsize_t    *space_dims     = NULL;
+    hsize_t    *space_maxdims  = NULL;
+    hid_t       dataspace      = FAIL;
+    char       *dataspace_type = NULL;
+    const char *path_name      = NULL;
+    hid_t       ret_value      = FAIL;
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Parsing dataspace from HTTP response\n\n");
@@ -2750,8 +2874,28 @@ RV_parse_dataspace(char *space)
     if (NULL == (parse_tree = yajl_tree_parse(space, NULL, 0)))
         FUNC_GOTO_ERROR(H5E_DATASPACE, H5E_PARSEERROR, FAIL, "JSON parse tree creation failed");
 
+    target_tree = parse_tree;
+
+    /* If the response contains 'h5paths',
+     * it may describe multiple objects. Needs to be unwrapped first. */
+    if (NULL != yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)) {
+        if (NULL == (key_obj = yajl_tree_get(parse_tree, h5paths_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "can't parse h5paths object");
+
+        /* Access the first object under h5paths */
+        if (NULL == (path_name = key_obj->u.object.keys[0]))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "parsed path name was NULL");
+
+        const char *path_keys[] = {path_name, (const char *)0};
+
+        if (NULL == (key_obj = yajl_tree_get(key_obj, path_keys, yajl_t_object)))
+            FUNC_GOTO_ERROR(H5E_OBJECT, H5E_PARSEERROR, FAIL, "unable to parse object under path key");
+
+        target_tree = key_obj;
+    }
+
     /* Retrieve the Dataspace type */
-    if (NULL == (key_obj = yajl_tree_get(parse_tree, dataspace_class_keys, yajl_t_string)))
+    if (NULL == (key_obj = yajl_tree_get(target_tree, dataspace_class_keys, yajl_t_string)))
         FUNC_GOTO_ERROR(H5E_DATASPACE, H5E_PARSEERROR, FAIL, "can't retrieve dataspace class");
 
     if (NULL == (dataspace_type = YAJL_GET_STRING(key_obj)))
@@ -2783,13 +2927,13 @@ RV_parse_dataspace(char *space)
         printf("-> SIMPLE dataspace\n\n");
 #endif
 
-        if (NULL == (dims_obj = yajl_tree_get(parse_tree, dataspace_dims_keys, yajl_t_array)))
+        if (NULL == (dims_obj = yajl_tree_get(target_tree, dataspace_dims_keys, yajl_t_array)))
             FUNC_GOTO_ERROR(H5E_DATASPACE, H5E_PARSEERROR, FAIL, "can't retrieve dataspace dims");
 
         /* Check to see whether the maximum dimension size is specified as part of the
          * dataspace's JSON representation
          */
-        if (NULL == (maxdims_obj = yajl_tree_get(parse_tree, dataspace_max_dims_keys, yajl_t_array)))
+        if (NULL == (maxdims_obj = yajl_tree_get(target_tree, dataspace_max_dims_keys, yajl_t_array)))
             maxdims_specified = FALSE;
 
         if (!YAJL_GET_ARRAY(dims_obj)->len)
@@ -3834,6 +3978,9 @@ RV_JSON_escape_string(const char *in, char *out, size_t *out_size)
 
     char *out_ptr                                  = NULL;
     char  escape_characters[NUM_JSON_ESCAPE_CHARS] = {'\b', '\f', '\n', '\r', '\t', '\"', '\\'};
+
+    if (!in)
+        FUNC_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "cannot JSON escape NULL string");
 
     if (out == NULL) {
         /* Determine necessary buffer size */

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -410,6 +410,12 @@ extern const char *link_creation_time_keys[];
  */
 extern const char *link_collection_keys2[];
 
+/* JSON keys to retrieve objects accessed through path(s) */
+extern const char *h5paths_keys[];
+
+/* JSON keys to retrieve the path to a domain in HSDS */
+extern const char *domain_keys[];
+
 /* A global struct containing the buffer which cURL will write its
  * responses out to after making a call to the server. The buffer
  * in this struct is allocated upon connector initialization and is
@@ -802,6 +808,8 @@ herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);
 
 #define SERVER_VERSION_SUPPORTS_FIXED_LENGTH_UTF8(version)                                                   \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
+
+#define SERVER_VERSION_SUPPORTS_LONG_NAMES(version) (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 6))
 
 #ifdef __cplusplus
 }

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -212,7 +212,7 @@ RV_dataset_create(void *obj, const H5VL_loc_params_t *loc_params, const char *na
                         "dataset create URL size exceeded maximum URL size");
 
 #ifdef RV_CONNECTOR_DEBUG
-    printf("-> Dataset creation request URL: %s\n\n", request_url);
+    printf("-> Dataset creation request endpoint: %s\n\n", request_endpoint);
 #endif
 
     http_response = RV_curl_post(curl, &new_dataset->domain->u.file.server_info, request_endpoint,
@@ -722,10 +722,6 @@ RV_dataset_read(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spac
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Reading dataset\n\n");
-
-    printf("   /***************************************\\\n");
-    printf("-> | Making GET/POST request to the server |\n");
-    printf("   \\***************************************/\n\n");
 #endif
 
     if (CURLM_OK != curl_multi_setopt(curl_multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS, NUM_MAX_HOST_CONNS))
@@ -1194,10 +1190,6 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
 
 #ifdef RV_CONNECTOR_DEBUG
     printf("-> Writing dataset\n\n");
-
-    printf("   /**********************************\\\n");
-    printf("-> | Making PUT request to the server |\n");
-    printf("   \\**********************************/\n\n");
 #endif
 
     if (CURLM_OK != curl_multi_setopt(curl_multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS, NUM_MAX_HOST_CONNS))


### PR DESCRIPTION
HDFGroup/hsds#296 (not yet complete) adds API endpoints which allow link names to be provided in the body of a POST request, rather than through the URL. This branch changes some operations (`RV_link_create`, `RV_link_specific`, `RV_find_object_by_path`) to use the newer API if it is available. 

Callbacks for `RV_find_object_by_path` were changed to handle a potential top-level `h5paths` key if the initial request was a plural attributes/links request. 

`RV_get_object_info_callback` needs the hrefs in the response to get the object's domain/file, and these hrefs aren't returned for links/attributes requests. Another change to the HSDS API (returning the domain for each link/attr?) is still needed to resolve this. 
