### PR TITLE
Compound subsetting through H5Tconvert and field selection

### DIFF
--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -440,6 +440,17 @@ extern RV_type_info *RV_type_info_array_g[];
  *                        *
  **************************/
 
+/* Values for the optimization of compound data reading and writing.  They indicate
+ * whether the fields of the source and destination are subset of each other
+ */
+typedef enum {
+    H5T_SUBSET_BADVALUE = -1, /* Invalid value */
+    H5T_SUBSET_FALSE    = 0,  /* Source and destination aren't subset of each other */
+    H5T_SUBSET_SRC,           /* Source is the subset of dest and no conversion is needed */
+    H5T_SUBSET_DST,           /* Dest is the subset of source and no conversion is needed */
+    H5T_SUBSET_CAP            /* Must be the last value */
+} RV_subset_t;
+
 /*
  * A struct which is used to return a link's name or the size of
  * a link's name when calling H5Lget_name_by_idx.
@@ -574,6 +585,10 @@ typedef struct dataset_write_info {
     curl_off_t  write_len;
     upload_info uinfo;
     const void *buf;
+
+    /* If writing using compound subsetting, this is a packed version of the
+     *  compound type containing only the selected members */
+    hid_t dense_cmpd_subset_dtype_id;
 } dataset_write_info;
 
 typedef struct dataset_read_info {
@@ -790,6 +805,12 @@ herr_t RV_convert_datatype_to_JSON(hid_t type_id, char **type_body, size_t *type
 /* Helper function to escape control characters for JSON strings */
 herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);
 
+/* Determine if a read from file to mem dtype is a compound subset read */
+herr_t RV_get_cmpd_subset_type(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subset_info);
+
+/* Helper to get information about members in dst that are included in src compound */
+herr_t RV_get_cmpd_subset_nmembers(hid_t src_type_id, hid_t dst_type_id, size_t *num_cmpd_members);
+
 #define SERVER_VERSION_MATCHES_OR_EXCEEDS(version, major_needed, minor_needed, patch_needed)                 \
     (version.major > major_needed) || (version.major == major_needed && version.minor > minor_needed) ||     \
         (version.major == major_needed && version.minor == minor_needed && version.patch >= patch_needed)
@@ -802,6 +823,9 @@ herr_t RV_JSON_escape_string(const char *in, char *out, size_t *out_size);
 
 #define SERVER_VERSION_SUPPORTS_FIXED_LENGTH_UTF8(version)                                                   \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
+
+#define SERVER_VERSION_SUPPORTS_MEMBER_SELECTION(version)                                                    \
+    (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 6))
 
 #ifdef __cplusplus
 }

--- a/src/rest_vol.h
+++ b/src/rest_vol.h
@@ -830,8 +830,7 @@ herr_t RV_get_cmpd_subset_nmembers(hid_t src_type_id, hid_t dst_type_id, size_t 
 #define SERVER_VERSION_SUPPORTS_FIXED_LENGTH_UTF8(version)                                                   \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 5))
 
-#define SERVER_VERSION_SUPPORTS_LONG_NAMES(version)                                                          \
-    (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 6))
+#define SERVER_VERSION_SUPPORTS_LONG_NAMES(version) (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 6))
 
 #define SERVER_VERSION_SUPPORTS_MEMBER_SELECTION(version)                                                    \
     (SERVER_VERSION_MATCHES_OR_EXCEEDS(version, 0, 8, 6))

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -1017,8 +1017,8 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
                 dest_dtype_size = dense_dtype_size;
             }
             else {
-                dest_dtype      = transfer_info[i].mem_type_id;
-                dest_dtype_size = mem_type_size;
+                dest_dtype      = transfer_info[i].file_type_id;
+                dest_dtype_size = file_type_size;
             }
 
             /* Initialize type conversion */

--- a/src/rest_vol_dataset.c
+++ b/src/rest_vol_dataset.c
@@ -1172,11 +1172,15 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
                                     "compound member names too long for URL");
 
                 /* Copy name to query string without null byte */
-                memcpy(cmpd_query_ptr, member_name, strlen(member_name));
-                cmpd_query_ptr += strlen(member_name);
+                memcpy(cmpd_query_ptr, url_encoded_member_name, strlen(url_encoded_member_name));
+                cmpd_query_ptr += strlen(url_encoded_member_name);
 
-                /* If another member name will follow, add sepator */
+                /* If another member name will follow, add separator */
                 if (j < num_cmpd_members - 1) {
+                    if ((size_t)(cmpd_query_ptr - cmpd_query) + 1 > URL_MAX_LENGTH)
+                        FUNC_GOTO_ERROR(H5E_DATASET, H5E_BADVALUE, FAIL,
+                                        "compound member names too long for URL");
+
                     *cmpd_query_ptr = COMPOUND_MEMBER_SEPARATOR;
                     cmpd_query_ptr++;
                 }
@@ -1189,6 +1193,9 @@ RV_dataset_write(size_t count, void *dset[], hid_t mem_type_id[], hid_t _mem_spa
                 curl_free(url_encoded_member_name);
                 url_encoded_member_name = NULL;
             }
+
+            if ((size_t)(cmpd_query_ptr - cmpd_query) + 1 > URL_MAX_LENGTH)
+                FUNC_GOTO_ERROR(H5E_DATASET, H5E_BADVALUE, FAIL, "compound member names too long for URL");
 
             *cmpd_query_ptr = '\0';
         }

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -2668,7 +2668,8 @@ RV_get_cmpd_subset_type(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subse
                                     "can't get destination datatype member offset");
 
                 /* Compare member names and offsets */
-                if (!strcmp(src_member_name, dst_member_name) && (src_member_offset == dst_member_offset)) {
+                if (!strcmp(src_member_name, dst_member_name) && (src_member_offset == dst_member_offset) &&
+                    (H5Tequal(src_member_type, dst_member_type) > 0)) {
                     member_match = TRUE;
                 }
 
@@ -2728,7 +2729,8 @@ RV_get_cmpd_subset_type(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subse
                                     "can't get memory datatype member offset");
 
                 /* Compare member names and offsets */
-                if (!strcmp(dst_member_name, src_member_name) && (dst_member_offset == src_member_offset)) {
+                if (!strcmp(dst_member_name, src_member_name) && (dst_member_offset == src_member_offset) &&
+                    (H5Tequal(dst_member_type, src_member_type) > 0)) {
                     member_match = TRUE;
                 }
                 /* Clean up */

--- a/src/rest_vol_datatype.c
+++ b/src/rest_vol_datatype.c
@@ -2616,10 +2616,11 @@ RV_get_cmpd_subset_type(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subse
 {
     herr_t      ret_value      = SUCCEED;
     H5T_class_t dst_type_class = H5T_NO_CLASS, src_type_class = H5T_NO_CLASS;
+    char       *src_member_name = NULL, *dst_member_name = NULL;
+    size_t      src_member_offset = 0, dst_member_offset = 0;
     hid_t       src_member_type = H5I_INVALID_HID, dst_member_type = H5I_INVALID_HID;
     int         dst_nmembs = 0, src_nmembs = 0;
-    htri_t      types_same           = false;
-    bool        match_for_src_member = false;
+    hbool_t     member_match = FALSE;
 
     if (H5T_NO_CLASS == (src_type_class = H5Tget_class(src_type_id)))
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "source datatype is invalid");
@@ -2638,20 +2639,137 @@ RV_get_cmpd_subset_type(hid_t src_type_id, hid_t dst_type_id, RV_subset_t *subse
     if ((src_nmembs = H5Tget_nmembers(src_type_id)) < 0)
         FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get nmembers of source datatype");
 
-    /* The library just compares the number of members to determine if two
-     * compounds are subsets, so that should suffice here as well. */
+    /* Determine subset status by comparing members */
+    if (src_nmembs < dst_nmembs) {
+        for (unsigned src_idx = 0; src_idx < src_nmembs; src_idx++) {
+            member_match = FALSE;
 
-    if (src_nmembs > dst_nmembs) {
-        *subset = H5T_SUBSET_DST;
+            if ((src_member_type = H5Tget_member_type(src_type_id, src_idx)) == H5I_INVALID_HID)
+                FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get memory datatype member type");
+
+            if ((src_member_name = H5Tget_member_name(src_type_id, src_idx)) == NULL)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get memory datatype member name");
+
+            if ((src_member_offset = H5Tget_member_offset(src_type_id, src_idx)) < 0)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get memory datatype member offset");
+
+            /* Search for match in dst compound */
+            for (unsigned dst_idx = 0; dst_idx < dst_nmembs; dst_idx++) {
+                if ((dst_member_type = H5Tget_member_type(dst_type_id, dst_idx)) == H5I_INVALID_HID)
+                    FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                    "can't get destination datatype member type");
+
+                if ((dst_member_name = H5Tget_member_name(dst_type_id, dst_idx)) == NULL)
+                    FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                    "can't get destination datatype member name");
+
+                if ((dst_member_offset = H5Tget_member_offset(dst_type_id, dst_idx)) < 0)
+                    FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                    "can't get destination datatype member offset");
+
+                /* Compare member names and offsets */
+                if (!strcmp(src_member_name, dst_member_name) && (src_member_offset == dst_member_offset)) {
+                    member_match = TRUE;
+                }
+
+                /* Clean up */
+                H5free_memory(dst_member_name);
+                dst_member_name = NULL;
+
+                if (H5Tclose(dst_member_type) < 0)
+                    FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL,
+                                    "can't close destination datatype member type");
+                dst_member_type = H5T_NO_CLASS;
+
+                /* If no match exists for this source member, the src compound is not a subset */
+                if ((dst_idx == dst_nmembs - 1) && !member_match) {
+                    *subset = H5T_SUBSET_FALSE;
+                    FUNC_GOTO_DONE(SUCCEED);
+                }
+            }
+
+            /* Clean up */
+            H5free_memory(src_member_name);
+            src_member_name = NULL;
+
+            if (H5Tclose(src_member_type) < 0)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close source datatype member");
+            src_member_type = H5T_NO_CLASS;
+
+            /* If a match was found for every member, src is a subset of dst */
+            *subset = H5T_SUBSET_SRC;
+        }
     }
-    else if (src_nmembs < dst_nmembs) {
-        *subset = H5T_SUBSET_SRC;
+    else if (dst_nmembs < src_nmembs) {
+        for (unsigned dst_idx = 0; dst_idx < dst_nmembs; dst_idx++) {
+            member_match = FALSE;
+            if ((dst_member_type = H5Tget_member_type(dst_type_id, dst_idx)) == H5I_INVALID_HID)
+                FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                "can't get destination datatype member type");
+
+            if ((dst_member_name = H5Tget_member_name(dst_type_id, dst_idx)) == NULL)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                "can't get destination datatype member name");
+
+            if ((dst_member_offset = H5Tget_member_offset(dst_type_id, dst_idx)) < 0)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                "can't get destination datatype member offset");
+
+            /* Search for match in src compound */
+            for (unsigned src_idx = 0; src_idx < src_nmembs; src_idx++) {
+                if ((src_member_type = H5Tget_member_type(src_type_id, src_idx)) == H5I_INVALID_HID)
+                    FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get memory datatype member type");
+
+                if ((src_member_name = H5Tget_member_name(src_type_id, src_idx)) == NULL)
+                    FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "can't get memory datatype member name");
+
+                if ((src_member_offset = H5Tget_member_offset(src_type_id, src_idx)) < 0)
+                    FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,
+                                    "can't get memory datatype member offset");
+
+                /* Compare member names and offsets */
+                if (!strcmp(dst_member_name, src_member_name) && (dst_member_offset == src_member_offset)) {
+                    member_match = TRUE;
+                }
+                /* Clean up */
+                H5free_memory(src_member_name);
+                src_member_name = NULL;
+
+                if (H5Tclose(src_member_type) < 0)
+                    FUNC_GOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL,
+                                    "can't close memory datatype member type");
+                src_member_type = H5T_NO_CLASS;
+
+                /* If no match exists for this destination member, the dst compound is not a subset */
+                if ((src_idx == src_nmembs - 1) && !member_match) {
+                    *subset = H5T_SUBSET_FALSE;
+                    FUNC_GOTO_DONE(SUCCEED);
+                }
+            }
+
+            /* Clean up */
+            H5free_memory(dst_member_name);
+            dst_member_name = NULL;
+
+            if (H5Tclose(dst_member_type) < 0)
+                FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL,
+                                "can't close destination datatype member");
+            dst_member_type = H5T_NO_CLASS;
+
+            /* If a match was found for every member, dst is a subset of source */
+            *subset = H5T_SUBSET_DST;
+        }
     }
     else {
         *subset = H5T_SUBSET_FALSE;
     }
 
 done:
+    if (src_member_name)
+        H5free_memory(src_member_name);
+    if (dst_member_name)
+        H5free_memory(dst_member_name);
+
     if (src_member_type > 0)
         if (H5Tclose(src_member_type) < 0)
             FUNC_DONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close source datatype member");


### PR DESCRIPTION
Alternative implementation of #107. Compound reads are handled through `H5Tconvert`. The previous issue with this - that `H5Tconvert` would overwrite the unused fields - is fixed by using the background buffer.

Compound writes are more complicated, since HSDS expects to receive a packed buffer containing only the data for the fields that are actually being written to. `H5Tconvert` leaves blank spaces in the buffer, so it was necessary to create the packed buffer through `H5Dgather` and a new callback. 

This depends on HDFGroup/HSDS#298, which fixes some issues with writing to field selections.