### PR TITLE
Require libcurl <8.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Get REST VOL dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev
+          sudo apt-get install libcurl4-openssl-dev=7.81
           sudo apt-get install libyajl-dev
 
       - name: Get Autotools Dependencies
@@ -169,7 +169,7 @@ jobs:
       - name: Get REST VOL dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev
+          sudo apt-get install libcurl4-openssl-dev=7.81
           sudo apt-get install libyajl-dev
               
       - name: Get REST VOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if (HDF5_ENABLE_THREADSAFE AND NOT Threads_FOUND)
   find_package(Threads)
 endif ()
 
-find_package (CURL 7.61 REQUIRED)
+find_package (CURL 7.61...<8.0.0 REQUIRED)
 if (CURL_FOUND)
   include_directories(${CURL_INCLUDE_DIRS})
   set (LINK_LIBS ${LINK_LIBS} CURL::libcurl)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To build the REST VOL connector, the following libraries are required:
             Additionally, the HDF5 library must have its high-level interface enabled at build time
             unless the REST VOL examples are disabled.
 
-+ libcurl (ver. 7.61.0 or greater) - networking support
++ libcurl (ver. >=7.61.0, <8.0.0) - networking support
     + https://curl.haxx.se/
 
 + libyajl (ver. 2.0.4 or greater) - JSON parsing and construction

--- a/config/cmake/rv-config.cmake.in
+++ b/config/cmake/rv-config.cmake.in
@@ -41,5 +41,5 @@ else ()
 endif ()
 
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} @PACKAGE_SHARE_INSTALL_DIR@/..)
-find_package (CURL 7.61 QUIET REQUIRED)
+find_package (CURL 7.61...<8.0.0 QUIET REQUIRED)
 find_package (YAJL 2.0.4 QUIET REQUIRED)


### PR DESCRIPTION
Dataset creation fails on libcurl >=8.0.0.

The only breaking changes in libcurl 8 dealt with curl_off_t, but I couldn't narrow down the particular problem.

For now, restrict the libcurl version to keep CI consistent.